### PR TITLE
Ability to produce & consume from service network

### DIFF
--- a/common/src/main/java/org/creekservice/api/kafka/common/config/ClustersProperties.java
+++ b/common/src/main/java/org/creekservice/api/kafka/common/config/ClustersProperties.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.kafka.common.config;
+
+import static java.util.Objects.requireNonNull;
+import static org.creekservice.api.base.type.Preconditions.requireNonBlank;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Holds Kafka client properties for connecting to multiple Kafka clusters.
+ *
+ * <p>Properties can be added for a specific cluster or common to all clusters. Specific properties
+ * override common.
+ *
+ * <p>The class is immutable(ish) and thread-safe, as long as the values of the map are considered
+ * immutable. The builder is not thread-safe.
+ */
+public final class ClustersProperties {
+
+    private final Map<String, Object> common;
+    private final Map<String, Map<String, ?>> clusters;
+
+    private ClustersProperties(
+            final Map<String, Object> common, final Map<String, Map<String, Object>> clusters) {
+        final Map<String, Map<String, Object>> copy = new HashMap<>();
+        clusters.forEach((k, v) -> copy.put(k, Map.copyOf(v)));
+        this.common = Map.copyOf(common);
+        this.clusters = Map.copyOf(copy);
+    }
+
+    public static Builder propertiesBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * Get Kafka client properties for the supplied {@code clusterName}.
+     *
+     * @param clusterName the name of the Kafka cluster.
+     * @return the properties, or an empty map if non are set.
+     */
+    public Map<String, ?> get(final String clusterName) {
+        final Map<String, Object> props = new HashMap<>(common);
+        props.putAll(clusterSpecific(clusterName));
+        return props;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ClustersProperties that = (ClustersProperties) o;
+        return Objects.equals(common, that.common) && Objects.equals(clusters, that.clusters);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(common, clusters);
+    }
+
+    @Override
+    public String toString() {
+        return "ClustersProperties{" + "common=" + common + ", byCluster=" + clusters + '}';
+    }
+
+    private Map<String, ?> clusterSpecific(final String clusterName) {
+        return clusters.getOrDefault(requireNonNull(clusterName, "clusterName"), Map.of());
+    }
+
+    public static final class Builder {
+
+        private final Map<String, Object> common = new HashMap<>();
+        private final Map<String, Map<String, Object>> clusters = new HashMap<>();
+
+        private Builder() {}
+
+        public Builder putCommon(final String name, final Object value) {
+            common.put(requireNonBlank(name, "name"), requireNonNull(value, "value"));
+            return this;
+        }
+
+        public Builder put(final String cluster, final String name, final Object value) {
+            clusters.computeIfAbsent(requireNonBlank(cluster, "cluster"), k -> new HashMap<>())
+                    .put(requireNonBlank(name, "name"), requireNonNull(value, "value"));
+            return this;
+        }
+
+        public Builder putAll(final ClustersProperties other) {
+            other.common.forEach(this::putCommon);
+            other.clusters.forEach(
+                    (clusterName, properties) ->
+                            properties.forEach((key, value) -> put(clusterName, key, value)));
+            return this;
+        }
+
+        public ClustersProperties build() {
+            return new ClustersProperties(common, clusters);
+        }
+    }
+}

--- a/common/src/main/java/org/creekservice/api/kafka/common/config/KafkaPropertyOverrides.java
+++ b/common/src/main/java/org/creekservice/api/kafka/common/config/KafkaPropertyOverrides.java
@@ -16,10 +16,8 @@
 
 package org.creekservice.api.kafka.common.config;
 
-
-import java.util.Map;
-
 /** A provider of Kafka properties overrides */
 public interface KafkaPropertyOverrides {
-    Map<String, Object> get();
+
+    ClustersProperties get();
 }

--- a/common/src/test/java/org/creekservice/api/kafka/common/config/ClustersPropertiesTest.java
+++ b/common/src/test/java/org/creekservice/api/kafka/common/config/ClustersPropertiesTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.kafka.common.config;
+
+import static org.creekservice.api.kafka.common.config.ClustersProperties.propertiesBuilder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ClustersPropertiesTest {
+
+    private ClustersProperties.Builder builder;
+
+    @BeforeEach
+    void setUp() {
+        builder = propertiesBuilder();
+    }
+
+    @Test
+    void shouldThrowOnNullPointers() {
+        final NullPointerTester tester =
+                new NullPointerTester().setDefault(String.class, "not empty");
+        tester.testAllPublicInstanceMethods(builder);
+        tester.testAllPublicInstanceMethods(propertiesBuilder().build());
+    }
+
+    @Test
+    void shouldImplementHashcodeAndEquals() {
+        new EqualsTester()
+                .addEqualityGroup(
+                        propertiesBuilder().put("a", "b", "c").putCommon("d", "e").build(),
+                        propertiesBuilder().put("a", "b", "c").putCommon("d", "e").build())
+                .addEqualityGroup(
+                        propertiesBuilder().put("diff", "b", "c").putCommon("d", "e").build())
+                .addEqualityGroup(
+                        propertiesBuilder().put("a", "diff", "c").putCommon("d", "e").build())
+                .addEqualityGroup(
+                        propertiesBuilder().put("a", "b", "diff").putCommon("d", "e").build())
+                .addEqualityGroup(
+                        propertiesBuilder().put("a", "b", "c").putCommon("diff", "e").build())
+                .addEqualityGroup(
+                        propertiesBuilder().put("a", "b", "c").putCommon("d", "diff").build())
+                .testEquals();
+    }
+
+    @Test
+    void shouldThrowOnBlankClusterName() {
+        assertThrows(IllegalArgumentException.class, () -> builder.put(" ", "k", "v"));
+    }
+
+    @Test
+    void shouldThrowOnBlankPropertyName() {
+        assertThrows(IllegalArgumentException.class, () -> builder.put("c", "", "v"));
+    }
+
+    @Test
+    void shouldNotExposeMutableProperties() {
+        // Given:
+        final ClustersProperties props = builder.put("cluster", "key", "value").build();
+        final Map<String, ?> clusterProps = props.get("cluster");
+
+        // When:
+        clusterProps.put("mutate", null);
+
+        // Then:
+        assertThat(props.get("cluster"), not(hasKey("mutate")));
+    }
+
+    @Test
+    void shouldUseMostSpecificProperty() {
+        // Given:
+        final ClustersProperties props =
+                builder.put("cluster-bob", "k", 1).putCommon("k", 2).build();
+
+        // When:
+        final Object result = props.get("cluster-bob").get("k");
+
+        // Then:
+        assertThat(result, is(1));
+    }
+
+    @Test
+    void shouldPutAllCommon() {
+        // Given:
+        builder.put("c", "k1", 1).putCommon("k2", 1);
+
+        final ClustersProperties other =
+                propertiesBuilder().putCommon("k1", 2).putCommon("k2", 2).build();
+
+        // When:
+        builder.putAll(other);
+
+        // Then:
+        final ClustersProperties props = builder.build();
+        assertThat(props.get("any").get("k1"), is(2));
+        assertThat(props.get("any").get("k2"), is(2));
+        assertThat(props.get("c").get("k1"), is(1));
+        assertThat(props.get("c").get("k2"), is(2));
+    }
+
+    @Test
+    void shouldPutAllSpecific() {
+        // Given:
+        builder.put("c", "k1", 1);
+
+        final ClustersProperties other =
+                propertiesBuilder().put("c", "k1", 2).put("c", "k2", 2).build();
+
+        // When:
+        builder.putAll(other);
+
+        // Then:
+        final ClustersProperties props = builder.build();
+        assertThat(props.get("c").get("k1"), is(2));
+        assertThat(props.get("c").get("k2"), is(2));
+    }
+
+    @Test
+    void shouldChainPutAll() {
+        // Given:
+        final ClustersProperties other = propertiesBuilder().put("c", "k1", 2).build();
+
+        // When:
+        builder.putAll(other).put("c", "k1", 1);
+
+        // Then:
+        final ClustersProperties props = builder.build();
+        assertThat(props.get("c").get("k1"), is(1));
+    }
+}

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/KafkaTopicDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/KafkaTopicDescriptor.java
@@ -27,6 +27,8 @@ import org.creekservice.api.platform.metadata.ResourceDescriptor;
  */
 public interface KafkaTopicDescriptor<K, V> extends ResourceDescriptor {
 
+    String DEFAULT_CLUSTER_NAME = "default";
+
     /** @return name of the topic as it is in Kafka. */
     String name();
 
@@ -35,10 +37,12 @@ public interface KafkaTopicDescriptor<K, V> extends ResourceDescriptor {
      *
      * <p>This name is used to look up connection details for the cluster.
      *
+     * <p>The name should be limited to alphanumeric characters.
+     *
      * @return the logical Kafka cluster name.
      */
     default String cluster() {
-        return "default";
+        return DEFAULT_CLUSTER_NAME;
     }
 
     /** @return metadata about the topic's key: */

--- a/streams-extension/src/main/java/module-info.java
+++ b/streams-extension/src/main/java/module-info.java
@@ -16,6 +16,7 @@ module creek.kafka.streams.extension {
     requires com.github.spotbugs.annotations;
 
     exports org.creekservice.api.kafka.streams.extension;
+    exports org.creekservice.api.kafka.streams.extension.exception;
     exports org.creekservice.api.kafka.streams.extension.observation;
     exports org.creekservice.api.kafka.streams.extension.util;
 

--- a/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtension.java
+++ b/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtension.java
@@ -33,9 +33,11 @@ public interface KafkaStreamsExtension extends CreekExtension {
      * <p>Note: the properties should be considered immutable. Changing them may result in undefined
      * behaviour.
      *
+     * @param clusterName the name of the Kafka cluster to get client properties for. Often will be
+     *     {@link KafkaTopicDescriptor#DEFAULT_CLUSTER_NAME}.
      * @return the properties.
      */
-    Properties properties();
+    Properties properties(String clusterName);
 
     /**
      * Get a topic resource for the supplied {@code def}.
@@ -49,9 +51,12 @@ public interface KafkaStreamsExtension extends CreekExtension {
      * Build a Kafka Streams app from the supplied {@code topology}.
      *
      * @param topology the topology to build.
+     * @param clusterName the name of the Kafka cluster to get client properties for. Often will be
+     *     {@link KafkaTopicDescriptor#DEFAULT_CLUSTER_NAME}. Note, topics used in streams
+     *     topologies must all be in the same cluster.
      * @return the streams app.
      */
-    KafkaStreams build(Topology topology);
+    KafkaStreams build(Topology topology, String clusterName);
 
     /**
      * Execute a Kafka Streams app.
@@ -66,6 +71,6 @@ public interface KafkaStreamsExtension extends CreekExtension {
      * @param topology the topology to build and execute.
      */
     default void execute(final Topology topology) {
-        execute(build(topology));
+        execute(build(topology, KafkaTopicDescriptor.DEFAULT_CLUSTER_NAME));
     }
 }

--- a/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/exception/StreamsExceptionHandlers.java
+++ b/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/exception/StreamsExceptionHandlers.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.kafka.streams.extension.exception;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.streams.errors.ProductionExceptionHandler;
+import org.creekservice.api.base.annotation.VisibleForTesting;
+import org.creekservice.api.observability.logging.structured.StructuredLogger;
+import org.creekservice.api.observability.logging.structured.StructuredLoggerFactory;
+
+public final class StreamsExceptionHandlers {
+
+    private StreamsExceptionHandlers() {}
+
+    private static final StructuredLogger LOGGER =
+            StructuredLoggerFactory.internalLogger(StreamsExceptionHandlers.class);
+
+    public static final class LogAndFailProductionExceptionHandler
+            implements ProductionExceptionHandler {
+
+        private final StructuredLogger logger;
+
+        @SuppressWarnings("unused") // Invoked via reflection
+        public LogAndFailProductionExceptionHandler() {
+            this(LOGGER);
+        }
+
+        @VisibleForTesting
+        LogAndFailProductionExceptionHandler(final StructuredLogger logger) {
+            this.logger = requireNonNull(logger, "logger");
+        }
+
+        @Override
+        public ProductionExceptionHandlerResponse handle(
+                final ProducerRecord<byte[], byte[]> record, final Exception exception) {
+
+            logger.error(
+                    "Failed to produce to topic",
+                    log ->
+                            log.with("topic", record.topic())
+                                    .with("partition", record.partition())
+                                    .with("key", Arrays.toString(record.key()))
+                                    .withThrowable(exception));
+
+            return ProductionExceptionHandlerResponse.FAIL;
+        }
+
+        @Override
+        public void configure(final Map<String, ?> configs) {}
+    }
+}

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsBuilder.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsBuilder.java
@@ -42,8 +42,8 @@ public final class KafkaStreamsBuilder {
         this.appFactory = requireNonNull(appFactory, "appFactory");
     }
 
-    public KafkaStreams build(final Topology topology) {
-        final Properties properties = options.properties();
+    public KafkaStreams build(final Topology topology, final String clusterName) {
+        final Properties properties = options.properties(clusterName);
         final KafkaClientSupplier kafkaClientSupplier = new DefaultKafkaClientSupplier();
 
         return appFactory.create(topology, properties, kafkaClientSupplier);

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsExtension.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsExtension.java
@@ -54,8 +54,8 @@ final class StreamsExtension implements KafkaStreamsExtension {
     }
 
     @Override
-    public Properties properties() {
-        return options.properties();
+    public Properties properties(final String clusterName) {
+        return options.properties(clusterName);
     }
 
     @Override
@@ -64,8 +64,8 @@ final class StreamsExtension implements KafkaStreamsExtension {
     }
 
     @Override
-    public KafkaStreams build(final Topology topology) {
-        return appBuilder.build(topology);
+    public KafkaStreams build(final Topology topology, final String clusterName) {
+        return appBuilder.build(topology, clusterName);
     }
 
     @Override

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistryFactory.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistryFactory.java
@@ -76,20 +76,21 @@ public final class ResourceRegistryFactory {
 
     private <K, V> Topic<K, V> createTopicResource(
             final KafkaTopicDescriptor<K, V> def, final KafkaStreamsExtensionOptions options) {
-        final Serde<K> keySerde = serde(def.key(), def.name(), true, options);
-        final Serde<V> valueSerde = serde(def.value(), def.name(), false, options);
+        final Serde<K> keySerde = serde(def.key(), def.name(), def.cluster(), true, options);
+        final Serde<V> valueSerde = serde(def.value(), def.name(), def.cluster(), false, options);
         return topicFactory.create(def, keySerde, valueSerde);
     }
 
     private <T> Serde<T> serde(
             final KafkaTopicDescriptor.PartDescriptor<T> part,
             final String topicName,
+            final String clusterName,
             final boolean isKey,
             final KafkaStreamsExtensionOptions options) {
         final KafkaSerdeProvider provider = provider(part, topicName, isKey);
 
         final Serde<T> serde = provider.create(part);
-        serde.configure(options.propertyMap(), isKey);
+        serde.configure(options.propertyMap(clusterName), isKey);
         return serde;
     }
 

--- a/streams-extension/src/test/java/org/creekservice/ModuleTest.java
+++ b/streams-extension/src/test/java/org/creekservice/ModuleTest.java
@@ -17,13 +17,21 @@
 package org.creekservice;
 
 
+import org.creekservice.api.kafka.streams.extension.exception.StreamsExceptionHandlers.LogAndFailProductionExceptionHandler;
 import org.creekservice.api.test.conformity.ConformityTester;
+import org.creekservice.api.test.conformity.check.CheckConstructorsPrivate;
 import org.junit.jupiter.api.Test;
 
 class ModuleTest {
 
     @Test
     void shouldConform() {
-        ConformityTester.test(ModuleTest.class);
+        ConformityTester.builder(ModuleTest.class)
+                .withCustom(
+                        CheckConstructorsPrivate.builder()
+                                .withExcludedClasses(
+                                        "Created by reflection",
+                                        LogAndFailProductionExceptionHandler.class))
+                .check();
     }
 }

--- a/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/exception/StreamsExceptionHandlersTest.java
+++ b/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/exception/StreamsExceptionHandlersTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.kafka.streams.extension.exception;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.streams.errors.ProductionExceptionHandler.ProductionExceptionHandlerResponse;
+import org.creekservice.api.kafka.streams.extension.exception.StreamsExceptionHandlers.LogAndFailProductionExceptionHandler;
+import org.creekservice.api.test.observability.logging.structured.TestStructuredLogger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StreamsExceptionHandlersTest {
+
+    private final TestStructuredLogger logger = TestStructuredLogger.create();
+    private final Exception exception = new IllegalArgumentException("BOOM");
+    private final ProducerRecord<byte[], byte[]> record =
+            new ProducerRecord<>(
+                    "some-topic",
+                    22,
+                    "key".getBytes(StandardCharsets.UTF_8),
+                    "value".getBytes(StandardCharsets.UTF_8));
+
+    private LogAndFailProductionExceptionHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new LogAndFailProductionExceptionHandler(logger);
+    }
+
+    @Test
+    void shouldDoNothingInConfigure() {
+        handler.configure(null);
+    }
+
+    @Test
+    void shouldLogErrorOnProduceFailure() {
+        // Then:
+        handler.handle(record, exception);
+
+        // Then:
+        assertThat(
+                logger.textEntries(),
+                contains(
+                        "ERROR: {key=[107, 101, 121], message=Failed to produce to topic, partition=22, topic=some-topic} "
+                                + "java.lang.IllegalArgumentException: BOOM"));
+    }
+
+    @Test
+    void shouldReturnFailToStopTheAppOnProduceFailure() {
+        // When:
+        final ProductionExceptionHandlerResponse result = handler.handle(record, exception);
+
+        // Then:
+        assertThat(result, is(ProductionExceptionHandlerResponse.FAIL));
+    }
+}

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsBuilderTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsBuilderTest.java
@@ -50,13 +50,22 @@ class KafkaStreamsBuilderTest {
         builder = new KafkaStreamsBuilder(options, appFactory);
 
         when(appFactory.create(any(), any(), any())).thenReturn(app);
-        when(options.properties()).thenReturn(properties);
+        when(options.properties(any())).thenReturn(properties);
+    }
+
+    @Test
+    void shouldGetPropertiesForCorrectCluster() {
+        // When:
+        builder.build(topology, "cluster");
+
+        // Then:
+        verify(options).properties("cluster");
     }
 
     @Test
     void shouldBuildStreamsApp() {
         // When:
-        builder.build(topology);
+        builder.build(topology, "cluster");
 
         // Then:
         verify(appFactory)
@@ -66,7 +75,7 @@ class KafkaStreamsBuilderTest {
     @Test
     void shouldReturnStreamsApp() {
         // When:
-        final KafkaStreams result = builder.build(topology);
+        final KafkaStreams result = builder.build(topology, "cluster");
 
         // Then:
         assertThat(result, is(app));

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsExtensionTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsExtensionTest.java
@@ -16,6 +16,7 @@
 
 package org.creekservice.internal.kafka.streams.extension;
 
+import static org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.DEFAULT_CLUSTER_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -57,8 +58,8 @@ class StreamsExtensionTest {
     void setUp() {
         extension = new StreamsExtension(options, resources, builder, executor);
 
-        when(options.properties()).thenReturn(properties);
-        when(builder.build(any())).thenReturn(app);
+        when(options.properties(any())).thenReturn(properties);
+        when(builder.build(any(), any())).thenReturn(app);
     }
 
     @Test
@@ -68,16 +69,21 @@ class StreamsExtensionTest {
 
     @Test
     void shouldReturnProperties() {
-        assertThat(extension.properties(), is(properties));
+        // When:
+        final Properties result = extension.properties("cluster-bob");
+
+        // Then:
+        assertThat(result, is(properties));
+        verify(options).properties("cluster-bob");
     }
 
     @Test
-    void shouldBuildTopology() {
+    void shouldBuildSpecificTopology() {
         // When:
-        final KafkaStreams result = extension.build(topology);
+        final KafkaStreams result = extension.build(topology, "cluster-bob");
 
         // Then:
-        verify(builder).build(topology);
+        verify(builder).build(topology, "cluster-bob");
         assertThat(result, is(app));
     }
 
@@ -96,7 +102,7 @@ class StreamsExtensionTest {
         extension.execute(topology);
 
         // Then:
-        verify(builder).build(topology);
+        verify(builder).build(topology, DEFAULT_CLUSTER_NAME);
         verify(executor).execute(app);
     }
 

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistryFactoryTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistryFactoryTest.java
@@ -50,6 +50,7 @@ class ResourceRegistryFactoryTest {
     private static final SerializationFormat KEY_FORMAT = serializationFormat("key-format");
     private static final SerializationFormat VALUE_FORMAT = serializationFormat("value-format");
     private static final Map<String, ?> SOME_CONFIG = Map.of("some", "config");
+    private static final String CLUSTER_NAME = "bob";
 
     @Mock private ComponentDescriptor component;
     @Mock private ResourceRegistryFactory.TopicCollector topicCollector;
@@ -162,7 +163,7 @@ class ResourceRegistryFactoryTest {
     @Test
     void shouldConfigureKeySerde() {
         // Given:
-        when(options.propertyMap()).thenReturn((Map) SOME_CONFIG);
+        when(options.propertyMap(CLUSTER_NAME)).thenReturn((Map) SOME_CONFIG);
 
         // When:
         factory.create(component, options);
@@ -175,7 +176,7 @@ class ResourceRegistryFactoryTest {
     @Test
     void shouldConfigureValueSerde() {
         // Given:
-        when(options.propertyMap()).thenReturn((Map) SOME_CONFIG);
+        when(options.propertyMap(CLUSTER_NAME)).thenReturn((Map) SOME_CONFIG);
 
         // When:
         factory.create(component, options);
@@ -257,6 +258,7 @@ class ResourceRegistryFactoryTest {
             final PartDescriptor<K> keyPart,
             final PartDescriptor<V> valuePart) {
         when(topic.name()).thenReturn(name);
+        when(topic.cluster()).thenReturn(CLUSTER_NAME);
         when(topic.key()).thenReturn(keyPart);
         when(topic.value()).thenReturn(valuePart);
     }

--- a/streams-test/src/main/java/org/creekservice/api/kafka/streams/test/TestTopics.java
+++ b/streams-test/src/main/java/org/creekservice/api/kafka/streams/test/TestTopics.java
@@ -99,7 +99,7 @@ public final class TestTopics {
         final TopicSerde<K, V> serde = new TopicSerde<>(topic.keySerde(), topic.valueSerde());
 
         final Map<String, Object> props = new HashMap<>();
-        final Properties properties = ext.properties();
+        final Properties properties = ext.properties(def.cluster());
         properties.stringPropertyNames().forEach(k -> props.put(k, properties.getProperty(k)));
 
         serde.configure(props);

--- a/streams-test/src/test/java/org/creekservice/api/kafka/streams/test/TestKafkaStreamsExtensionOptionsTest.java
+++ b/streams-test/src/test/java/org/creekservice/api/kafka/streams/test/TestKafkaStreamsExtensionOptionsTest.java
@@ -31,7 +31,7 @@ class TestKafkaStreamsExtensionOptionsTest {
         // When:
         final Object stateDir =
                 TestKafkaStreamsExtensionOptions.defaults()
-                        .properties()
+                        .properties("any")
                         .get(StreamsConfig.STATE_DIR_CONFIG);
 
         // Then:

--- a/streams-test/src/test/java/org/creekservice/api/kafka/streams/test/TestTopicsTest.java
+++ b/streams-test/src/test/java/org/creekservice/api/kafka/streams/test/TestTopicsTest.java
@@ -18,6 +18,7 @@ package org.creekservice.api.kafka.streams.test;
 
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static org.apache.kafka.streams.KeyValue.pair;
+import static org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.DEFAULT_CLUSTER_NAME;
 import static org.creekservice.api.kafka.streams.test.util.TestServiceDescriptor.InputTopic;
 import static org.creekservice.api.kafka.streams.test.util.TestServiceDescriptor.OutputTopic;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -61,7 +62,9 @@ class TestTopicsTest {
     void setUp() {
         testDriver =
                 new TopologyTestDriver(
-                        topology(), ctx.extension(KafkaStreamsExtension.class).properties());
+                        topology(),
+                        ctx.extension(KafkaStreamsExtension.class)
+                                .properties(DEFAULT_CLUSTER_NAME));
     }
 
     @AfterEach
@@ -110,6 +113,7 @@ class TestTopicsTest {
         builder.stream(InputTopic.name(), Consumed.with(Serdes.String(), Serdes.Long()))
                 .to(OutputTopic.name(), Produced.with(Serdes.String(), Serdes.Long()));
 
-        return builder.build(ctx.extension(KafkaStreamsExtension.class).properties());
+        return builder.build(
+                ctx.extension(KafkaStreamsExtension.class).properties(DEFAULT_CLUSTER_NAME));
     }
 }

--- a/test-extension/build.gradle.kts
+++ b/test-extension/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 }
 
 val creekSystemTestVersion : String by extra
+val creekBaseVersion : String by extra
 val testContainersVersion : String by extra
 val kafkaVersion : String by extra
 
@@ -26,6 +27,9 @@ dependencies {
     api(project(":metadata"))
     api("org.creekservice:creek-system-test-extension:$creekSystemTestVersion")
 
+    implementation("org.creekservice:creek-base-type:$creekBaseVersion")
+
+    testImplementation(project(":test-service"))
     testImplementation("org.creekservice:creek-system-test-test-util:$creekSystemTestVersion")
     testImplementation("org.testcontainers:testcontainers:$testContainersVersion")
     testImplementation("org.apache.kafka:kafka-clients:$kafkaVersion")

--- a/test-extension/src/main/java/module-info.java
+++ b/test-extension/src/main/java/module-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 
 import org.creekservice.api.system.test.extension.CreekTestExtension;
 import org.creekservice.internal.kafka.streams.test.extension.KafkaStreamsTestExtension;
@@ -5,6 +21,7 @@ import org.creekservice.internal.kafka.streams.test.extension.KafkaStreamsTestEx
 module creek.kafka.streams.test.extension {
     requires transitive creek.system.test.extension;
     requires creek.kafka.metadata;
+    requires creek.base.type;
 
     provides CreekTestExtension with
             KafkaStreamsTestExtension;

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDef.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDef.java
@@ -30,8 +30,9 @@ import org.creekservice.api.system.test.extension.service.ServiceInstance.ExecRe
 final class KafkaContainerDef implements ServiceDefinition {
 
     public static final int TEST_NETWORK_PORT = 9093;
-    private static final int SERVICE_NETWORK_PORT = 9092;
+    public static final int SERVICE_NETWORK_PORT = 9092;
     private static final int ZOOKEEPER_PORT = 2181;
+    private static final String DEFAULT_INTERNAL_PARTITION_COUNT = "1";
     private static final String DEFAULT_INTERNAL_TOPIC_RF = "1";
 
     private final String name;
@@ -136,8 +137,11 @@ final class KafkaContainerDef implements ServiceDefinition {
                 // port of test-network listener is not known until the service starts:
                 .addEnv("KAFKA_ADVERTISED_LISTENERS", serviceNetworkListener(instance))
                 .addEnv("KAFKA_BROKER_ID", "1")
+                .addEnv("KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS", DEFAULT_INTERNAL_PARTITION_COUNT)
                 .addEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", DEFAULT_INTERNAL_TOPIC_RF)
-                .addEnv("KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS", DEFAULT_INTERNAL_TOPIC_RF)
+                .addEnv(
+                        "KAFKA_TRANSACTION_STATE_LOG_NUM_PARTITIONS",
+                        DEFAULT_INTERNAL_PARTITION_COUNT)
                 .addEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", DEFAULT_INTERNAL_TOPIC_RF)
                 .addEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", DEFAULT_INTERNAL_TOPIC_RF)
                 .addEnv("KAFKA_LOG_FLUSH_INTERVAL_MESSAGES", Long.MAX_VALUE + "")

--- a/test-extension/src/test/java/module-info.test
+++ b/test-extension/src/test/java/module-info.test
@@ -1,8 +1,8 @@
 --add-modules
-  org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity,testcontainers,creek.system.test.executor,kafka.clients,creek.system.test.test.util,docker.java.api
+  org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity,testcontainers,creek.system.test.executor,kafka.clients,creek.system.test.test.util,docker.java.api,creek.kafka.test.service
 
 --add-reads
-  creek.kafka.streams.test.extension=org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity,testcontainers,creek.system.test.executor,kafka.clients,creek.system.test.test.util,docker.java.api
+  creek.kafka.streams.test.extension=org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity,testcontainers,creek.system.test.executor,kafka.clients,creek.system.test.test.util,docker.java.api,creek.kafka.test.service
 
 --add-opens
   org.junitpioneer/org.junitpioneer.jupiter=org.junit.platform.commons

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/StreamsTestLifecycleListenerFunctionalTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/StreamsTestLifecycleListenerFunctionalTest.java
@@ -16,6 +16,8 @@
 
 package org.creekservice.internal.kafka.streams.test.extension.testsuite;
 
+import static org.creekservice.api.kafka.test.service.TestServiceDescriptor.InputTopic;
+import static org.creekservice.api.kafka.test.service.TestServiceDescriptor.OutputTopic;
 import static org.creekservice.api.system.test.test.util.CreekSystemTestExtensionTester.extensionTester;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -34,7 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -50,12 +52,16 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
-import org.creekservice.api.platform.metadata.ServiceDescriptor;
 import org.creekservice.api.system.test.extension.CreekSystemTest;
 import org.creekservice.api.system.test.extension.service.ConfigurableServiceInstance;
+import org.creekservice.api.system.test.extension.service.ServiceContainer;
 import org.creekservice.api.system.test.extension.service.ServiceInstance;
 import org.creekservice.api.system.test.test.util.CreekSystemTestExtensionTester;
 import org.hamcrest.Description;
@@ -75,28 +81,23 @@ class StreamsTestLifecycleListenerFunctionalTest {
 
     private static final CreekSystemTestExtensionTester EXT_TESTER = extensionTester();
     private static StreamsTestLifecycleListener listener;
+    private static ConfigurableServiceInstance testService;
 
     private final DockerClient dockerClient = DockerClientFactory.lazyClient();
 
     @BeforeAll
     static void beforeAll() {
-        final KafkaTopicDescriptor<?, ?> kafkaResource0 = mock(KafkaTopicDescriptor.class);
-        when(kafkaResource0.cluster()).thenReturn("default");
-
-        final ServiceDescriptor serviceDescriptor = mock(ServiceDescriptor.class);
-        when(serviceDescriptor.resources()).thenReturn(Stream.of(kafkaResource0));
+        final ServiceContainer services = EXT_TESTER.dockerServicesContainer();
 
         final CreekSystemTest api =
                 mock(CreekSystemTest.class, withSettings().defaultAnswer(new ReturnsDeepStubs()));
 
         when(api.testSuite().services().add(any()))
-                .thenAnswer(inv -> EXT_TESTER.dockerServicesContainer().add(inv.getArgument(0)));
+                .thenAnswer(inv -> services.add(inv.getArgument(0)));
 
-        final ConfigurableServiceInstance kafkaServiceUnderTest =
-                mock(ConfigurableServiceInstance.class);
-        when(kafkaServiceUnderTest.descriptor()).thenReturn(Optional.of(serviceDescriptor));
+        testService = services.add(EXT_TESTER.serviceDefinitions().get("test-service"));
 
-        when(api.testSuite().services().stream()).thenReturn(Stream.of(kafkaServiceUnderTest));
+        when(api.testSuite().services().stream()).thenReturn(Stream.of(testService));
 
         listener = new StreamsTestLifecycleListener(api);
     }
@@ -119,21 +120,13 @@ class StreamsTestLifecycleListenerFunctionalTest {
     }
 
     @Test
-    void shouldBeAbleToProduceAndConsumeFromTestNetwork() throws Exception {
+    void shouldBeAbleToProduceAndConsumeFromTestNetwork() {
         // Given:
-        givenTopic();
+        givenTopic("test-topic");
 
-        try (KafkaConsumer<String, String> consumer = kafkaConsumer()) {
+        try (KafkaConsumer<String, String> consumer = kafkaConsumer("test-topic", String.class)) {
 
-            consumer.subscribe(List.of("test-topic"));
-            consumer.poll(Duration.ofSeconds(5));
-
-            try (KafkaProducer<String, String> producer = kafkaProducer()) {
-
-                // When:
-                producer.send(new ProducerRecord<>("test-topic", "key", "value"))
-                        .get(1, TimeUnit.HOURS);
-            }
+            produce("test-topic", "key", "value");
 
             // Then:
             final ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
@@ -142,6 +135,29 @@ class StreamsTestLifecycleListenerFunctionalTest {
             final ConsumerRecord<String, String> record = records.iterator().next();
             assertThat(record.key(), is("key"));
             assertThat(record.value(), is("value"));
+        }
+    }
+
+    @Test
+    void shouldBeAbleToProduceAndConsumeFromServiceNetwork() {
+        // Given:
+        givenTopic(InputTopic.name());
+        givenTopic(OutputTopic.name());
+
+        try (KafkaConsumer<Long, String> consumer = kafkaConsumer(OutputTopic)) {
+
+            testService.start();
+
+            // When:
+            produce(InputTopic.name(), "k", 100L);
+
+            // Then:
+            final ConsumerRecords<Long, String> records = consumer.poll(Duration.ofSeconds(60));
+
+            assertThat(records.count(), is(1));
+            final ConsumerRecord<Long, String> record = records.iterator().next();
+            assertThat(record.key(), is(100L));
+            assertThat(record.value(), is("k"));
         }
     }
 
@@ -175,10 +191,10 @@ class StreamsTestLifecycleListenerFunctionalTest {
     @SuppressFBWarnings(
             value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
             justification = "https://github.com/spotbugs/spotbugs/issues/756")
-    private void givenTopic() {
+    private void givenTopic(final String name) {
         try (Admin adminClient = Admin.create(baseProps())) {
             adminClient
-                    .createTopics(List.of(new NewTopic("test-topic", 1, (short) 1)))
+                    .createTopics(List.of(new NewTopic(name, 1, (short) 1)))
                     .all()
                     .get(1, TimeUnit.HOURS);
         } catch (ExecutionException | TimeoutException | InterruptedException e) {
@@ -186,27 +202,63 @@ class StreamsTestLifecycleListenerFunctionalTest {
         }
     }
 
-    private KafkaProducer<String, String> kafkaProducer() {
+    private <V> void produce(final String topic, final String key, final V value) {
+        try (KafkaProducer<String, V> producer = kafkaProducer(value)) {
+            producer.send(new ProducerRecord<>(topic, key, value));
+            producer.flush();
+        } catch (final Exception e) {
+            throw new AssertionError("Failed to produce", e);
+        }
+    }
+
+    private <V> KafkaProducer<String, V> kafkaProducer(final V value) {
         final Map<String, Object> producerProps = baseProps();
-        producerProps.put(
-                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        producerProps.put(
-                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, serializer(value));
 
         return new KafkaProducer<>(producerProps);
     }
 
-    private KafkaConsumer<String, String> kafkaConsumer() {
-        final Map<String, Object> consumerProps = baseProps();
-        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "Bob");
-        consumerProps.put(
-                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        consumerProps.put(
-                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-
-        return new KafkaConsumer<>(consumerProps);
+    private Class<? extends Serializer<?>> serializer(final Object value) {
+        if (value instanceof String) {
+            return StringSerializer.class;
+        }
+        if (value instanceof Long) {
+            return LongSerializer.class;
+        }
+        throw new IllegalArgumentException("Unsupported: " + value);
     }
 
+    @SuppressWarnings("SameParameterValue")
+    private <K> KafkaConsumer<K, String> kafkaConsumer(
+            final KafkaTopicDescriptor<K, String> topic) {
+        return kafkaConsumer(topic.name(), topic.key().type());
+    }
+
+    private <K> KafkaConsumer<K, String> kafkaConsumer(
+            final String topicName, final Class<K> keyType) {
+        final Map<String, Object> consumerProps = baseProps();
+        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+        consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, deserializer(keyType));
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        final KafkaConsumer<K, String> consumer = new KafkaConsumer<>(consumerProps);
+        consumer.subscribe(List.of(topicName));
+        return consumer;
+    }
+
+    private Class<? extends Deserializer<?>> deserializer(final Class<?> valueType) {
+        if (valueType.equals(String.class)) {
+            return StringDeserializer.class;
+        }
+        if (valueType.equals(Long.class)) {
+            return LongDeserializer.class;
+        }
+        throw new IllegalArgumentException("Unsupported type: " + valueType);
+    }
+
+    @SuppressWarnings("SameParameterValue")
     private static ServiceInstance serviceInstance(final String instanceName) {
         return EXT_TESTER.dockerServicesContainer().stream()
                 .filter(i -> Objects.equals(i.name(), instanceName))

--- a/test-service/include/log4j/log4j2.xml
+++ b/test-service/include/log4j/log4j2.xml
@@ -25,10 +25,10 @@
         <Logger name="org.creekservice" level="DEBUG" additivity="false">
             <AppenderRef ref="console"/>
         </Logger>
-        <Logger name="kafka" level="debug" additivity="false">
+        <Logger name="kafka" level="info" additivity="false">
             <AppenderRef ref="console"/>
         </Logger>
-        <Logger name="org.apache.kafka" level="debug" additivity="false">
+        <Logger name="org.apache.kafka" level="info" additivity="false">
             <AppenderRef ref="console"/>
         </Logger>
         <Root level="INFO">

--- a/test-service/src/main/java/module-info.java
+++ b/test-service/src/main/java/module-info.java
@@ -1,5 +1,14 @@
+
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+
 module creek.kafka.test.service {
+    requires transitive creek.kafka.metadata;
     requires creek.service.context;
     requires creek.kafka.streams.extension;
     requires org.apache.logging.log4j;
+
+    exports org.creekservice.api.kafka.test.service;
+
+    provides ComponentDescriptor with
+            org.creekservice.api.kafka.test.service.TestServiceDescriptor;
 }

--- a/test-service/src/main/java/org/creekservice/internal/kafka/test/service/kafka/streams/TopologyBuilder.java
+++ b/test-service/src/main/java/org/creekservice/internal/kafka/test/service/kafka/streams/TopologyBuilder.java
@@ -17,6 +17,7 @@
 package org.creekservice.internal.kafka.test.service.kafka.streams;
 
 import static java.util.Objects.requireNonNull;
+import static org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.DEFAULT_CLUSTER_NAME;
 import static org.creekservice.api.kafka.test.service.TestServiceDescriptor.InputTopic;
 import static org.creekservice.api.kafka.test.service.TestServiceDescriptor.OutputTopic;
 
@@ -51,13 +52,15 @@ public final class TopologyBuilder {
                         inputTopic.name(),
                         Consumed.with(inputTopic.keySerde(), inputTopic.valueSerde())
                                 .withName(name.name("ingest-" + inputTopic.name())))
+                .peek((k, v) -> System.out.println("received " + k + "-> " + v))
                 .transform(switchKeyAndValue(), name.named("switch"))
+                .peek((k, v) -> System.out.println("producing " + k + "-> " + v))
                 .to(
                         outputTopic.name(),
                         Produced.with(outputTopic.keySerde(), outputTopic.valueSerde())
                                 .withName(name.name("egress-" + outputTopic.name())));
 
-        return builder.build(ext.properties());
+        return builder.build(ext.properties(DEFAULT_CLUSTER_NAME));
     }
 
     private TransformerSupplier<String, Long, KeyValue<Long, String>> switchKeyAndValue() {


### PR DESCRIPTION
Enhance Kafka client properties to be multi-cluster. (Not needed for Streams, which is single cluster, but `KafkaTopicDescriptor` supports `cluster()`, so...)

Wire in remaining properties to allow a streams based microservice to be started and run against local Kafka.  Add test to prove test service can consume and produce to Kafka.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended