### PR TITLE
Better env var Kafka client props.

### DIFF
--- a/common/src/main/java/module-info.java
+++ b/common/src/main/java/module-info.java
@@ -7,5 +7,9 @@ module creek.kafka.common {
     exports org.creekservice.api.kafka.common.config;
     exports org.creekservice.api.kafka.common.resource;
     exports org.creekservice.internal.kafka.common.resource to
-            creek.kafka.streams.extension;
+            creek.kafka.streams.extension,
+            creek.kafka.streams.test.extension;
+    exports org.creekservice.internal.kafka.common.config to
+            creek.kafka.streams.extension,
+            creek.kafka.streams.test.extension;
 }

--- a/common/src/main/java/org/creekservice/api/kafka/common/config/KafkaPropertyOverrides.java
+++ b/common/src/main/java/org/creekservice/api/kafka/common/config/KafkaPropertyOverrides.java
@@ -16,8 +16,17 @@
 
 package org.creekservice.api.kafka.common.config;
 
-/** A provider of Kafka properties overrides */
+
+import java.util.Set;
+
+/** A provider of Kafka client properties overrides */
 public interface KafkaPropertyOverrides {
 
-    ClustersProperties get();
+    /**
+     * Get Kafka client property overrides.
+     *
+     * @param clusterNames the set of known Kafka cluster names.
+     * @return property overrides.
+     */
+    ClustersProperties get(Set<String> clusterNames);
 }

--- a/common/src/main/java/org/creekservice/api/kafka/common/config/SystemEnvPropertyOverrides.java
+++ b/common/src/main/java/org/creekservice/api/kafka/common/config/SystemEnvPropertyOverrides.java
@@ -16,58 +16,137 @@
 
 package org.creekservice.api.kafka.common.config;
 
-import static java.util.regex.Pattern.compile;
 import static org.creekservice.api.kafka.common.config.ClustersProperties.propertiesBuilder;
+import static org.creekservice.internal.kafka.common.config.SystemEnvProperties.prefix;
+import static org.creekservice.internal.kafka.common.config.SystemEnvProperties.propertyName;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.creekservice.api.base.annotation.VisibleForTesting;
+import org.creekservice.internal.kafka.common.config.SystemEnvProperties;
 
 /**
  * Loads Kafka client property overrides from environment variables.
  *
- * <p>Variable names are made up of three parts:
+ * <p>Variables can either target a specific cluster name or be common across all clusters.
  *
- * <ol>
- *   <li>A {@code KAFKA_} prefix
- *   <li>The uppercase cluster name, (as referenced from {@link
- *       org.creekservice.api.kafka.metadata.KafkaTopicDescriptor#cluster()}).
- *   <li>The Kafka client property name, in uppercase, with periods replaced with underscores {@code
- *       _}
- * </ol>
+ * <p>Common variables, not targeted at a specific cluster, or where the service only accesses a
+ * single cluster (which is the most common pattern), should have variable names in the format:
+ * {@code KAFKA_&lt;PROPERTY_NAME&gt;} where:
  *
- * <p>For example, config {@code boostrap.servers} for the {@code default} cluster can be set with a
- * variable name of {@code KAFKA_DEFAULT_BOOTSTRAP_SERVERS}.
+ * <ul>
+ *   <li><i>PROPERTY_NAME</i> is Kafka client property name, in uppercase, with periods {@code .}
+ *       replaced with underscores {@code _}
+ * </ul>
+ *
+ * <p>For example, config {@code boostrap.servers} can be set with a variable name of {@code
+ * KAFKA_BOOTSTRAP_SERVERS}.
+ *
+ * <p>In the unusual situation that a service access multiple Kafka clusters, a variable can target
+ * at a specific Kafka cluster. Such variables should have a name in the format: {@code
+ * KAFKA_&lt;CLUSTER_NAME&gt;_&lt;PROPERTY_NAME&gt;} where:
+ *
+ * <ul>
+ *   <li><i>CLUSTER_NAME</i> is the specific name of the Kafka cluster, as returned by {@link
+ *       org.creekservice.api.kafka.metadata.KafkaTopicDescriptor#cluster()}), in uppercase and any
+ *       dashes {@code -} replaced with underscores {@code _}.
+ *   <li><i>PROPERTY_NAME</i> is Kafka client property name, in uppercase, with periods {@code .}
+ *       replaced with underscores {@code _}
+ * </ul>
+ *
+ * <p>For example, config {@code boostrap.servers} for the {@code main-cluster} cluster can be set
+ * with a variable name of {@code KAFKA_MAIN_CLUSTER_BOOTSTRAP_SERVERS}.
  */
 public final class SystemEnvPropertyOverrides implements KafkaPropertyOverrides {
 
-    private static final Pattern KAFKA_PROPERTY_PATTERN =
-            compile("KAFKA_(?<cluster>[^_]*)_(?<name>.*)");
+    private final Map<String, ?> env;
 
     public static KafkaPropertyOverrides systemEnvPropertyOverrides() {
-        return new SystemEnvPropertyOverrides();
+        return new SystemEnvPropertyOverrides(System.getenv());
     }
 
-    private SystemEnvPropertyOverrides() {}
+    @VisibleForTesting
+    SystemEnvPropertyOverrides(final Map<String, ?> env) {
+        this.env =
+                env.entrySet().stream()
+                        .filter(e -> e.getKey().startsWith(SystemEnvProperties.KAFKA_PREFIX))
+                        .collect(
+                                Collectors.toUnmodifiableMap(
+                                        Map.Entry::getKey, Map.Entry::getValue));
+    }
 
     @Override
-    public ClustersProperties get() {
+    public ClustersProperties get(final Set<String> clusterNames) {
+
+        final Set<String> specificPrefixes =
+                clusterNames.stream()
+                        .map(SystemEnvProperties::prefix)
+                        .collect(Collectors.toUnmodifiableSet());
+
         final ClustersProperties.Builder properties = propertiesBuilder();
 
-        System.getenv()
-                .forEach(
-                        (k, v) -> {
-                            final Matcher matcher = KAFKA_PROPERTY_PATTERN.matcher(k);
-                            if (!matcher.matches()) {
-                                return;
-                            }
-
-                            final String cluster = matcher.group("cluster").toLowerCase();
-                            final String name =
-                                    matcher.group("name").replaceAll("_", ".").toLowerCase();
-
-                            properties.put(cluster, name, v);
-                        });
+        extractCommon(specificPrefixes, properties);
+        clusterNames.forEach(name -> extractSpecific(name, specificPrefixes, properties));
 
         return properties.build();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getClass());
+    }
+
+    private void extractCommon(
+            final Set<String> excludedPrefixes, final ClustersProperties.Builder properties) {
+        env.entrySet().stream()
+                .filter(e -> notExcludedPrefix(e.getKey(), excludedPrefixes))
+                .forEach(
+                        e ->
+                                propertyName(e.getKey(), "")
+                                        .ifPresent(
+                                                propName ->
+                                                        properties.putCommon(
+                                                                propName, e.getValue())));
+    }
+
+    private void extractSpecific(
+            final String clusterName,
+            final Set<String> specificPrefixes,
+            final ClustersProperties.Builder properties) {
+
+        final String requiredPrefix = prefix(clusterName);
+        final Set<String> excludedPrefixes = excludedPrefixes(specificPrefixes, requiredPrefix);
+
+        env.entrySet().stream()
+                .filter(e -> e.getKey().startsWith(requiredPrefix))
+                .filter(e -> notExcludedPrefix(e.getKey(), excludedPrefixes))
+                .forEach(
+                        e ->
+                                propertyName(e.getKey(), clusterName)
+                                        .ifPresent(
+                                                propName ->
+                                                        properties.put(
+                                                                clusterName,
+                                                                propName,
+                                                                e.getValue())));
+    }
+
+    private static Set<String> excludedPrefixes(
+            final Set<String> specificPrefixes, final String allowedPrefix) {
+        final Set<String> excludedPrefixes = new HashSet<>(specificPrefixes);
+        excludedPrefixes.removeIf(allowedPrefix::startsWith);
+        return Set.copyOf(excludedPrefixes);
+    }
+
+    private static boolean notExcludedPrefix(final String key, final Set<String> prefixes) {
+        return prefixes.stream().noneMatch(key::startsWith);
     }
 }

--- a/common/src/main/java/org/creekservice/internal/kafka/common/config/SystemEnvProperties.java
+++ b/common/src/main/java/org/creekservice/internal/kafka/common/config/SystemEnvProperties.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.common.config;
+
+
+import java.util.Optional;
+
+/**
+ * Util class for mapping between Kafka Client Property names and system environment variable names.
+ */
+public final class SystemEnvProperties {
+
+    public static final String KAFKA_PREFIX = "KAFKA_";
+
+    private SystemEnvProperties() {}
+
+    /**
+     * Get the environment variable name prefix for the supplied {@code clusterName}
+     *
+     * @param clusterName the cluster name, as returned by {@link
+     *     org.creekservice.api.kafka.metadata.KafkaTopicDescriptor#cluster()}
+     * @return the environment variable name prefix.
+     */
+    public static String prefix(final String clusterName) {
+        return clusterName.isBlank()
+                ? KAFKA_PREFIX
+                : KAFKA_PREFIX + clusterName.replaceAll("-", "_").toUpperCase() + "_";
+    }
+
+    /**
+     * Convert a Kafka client {@code propertyName} into a variable name for the supplied {@code
+     * clusterName}
+     *
+     * <p>If cluster name is empty then the variable name returned will be a common name, i.e.
+     * affecting all clusters.
+     *
+     * @param propertyName the property name to convert, e.g. {@code "bootstrap.servers"}
+     * @param clusterName the cluster name, may be empty if the variable should affect all clusters.
+     * @return the name to use for the environment name
+     */
+    public static String varName(final String propertyName, final String clusterName) {
+        return prefix(clusterName) + propertyName.replaceAll("\\.", "_").toUpperCase();
+    }
+
+    /**
+     * Convert an environment {@code variableName} into a Kafka client property name for the
+     * supplied {@code clusterName}
+     *
+     * @param variableName the environment variable name to convert.
+     * @param clusterName the cluster name, may be empty if the variable affects all clusters.
+     * @return the Kafka client property name.
+     */
+    public static Optional<String> propertyName(
+            final String variableName, final String clusterName) {
+        final String prefix = prefix(clusterName);
+        if (!variableName.startsWith(prefix)) {
+            return Optional.empty();
+        }
+        final String propName = variableName.substring(prefix.length());
+        return propName.isEmpty()
+                ? Optional.empty()
+                : Optional.of(propName.replaceAll("_", ".").toLowerCase());
+    }
+}

--- a/common/src/main/java/org/creekservice/internal/kafka/common/resource/KafkaResourceValidator.java
+++ b/common/src/main/java/org/creekservice/internal/kafka/common/resource/KafkaResourceValidator.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.common.resource;
+
+
+import java.util.stream.Stream;
+import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+
+/**
+ * Validator of Kafka based service resources, e.g. {@link KafkaTopicDescriptor}, etc.
+ *
+ * <p>Resources such as {@link KafkaTopicDescriptor} are just interfaces. Services are free to
+ * implement however they choose. Because of this, validation is a good thing!
+ */
+public final class KafkaResourceValidator {
+
+    /**
+     * Validate Kafka resources used by each of the supplied {@code components}
+     *
+     * @param components the components to validate
+     */
+    public void validate(final Stream<? extends ComponentDescriptor> components) {
+        components
+                .flatMap(ComponentDescriptor::resources)
+                .filter(KafkaTopicDescriptor.class::isInstance)
+                .map(d -> (KafkaTopicDescriptor<?, ?>) d)
+                .forEach(KafkaResourceValidator::validate);
+    }
+
+    private static void validate(final KafkaTopicDescriptor<?, ?> descriptor) {
+        requireNonBlank("name()", descriptor.name(), descriptor);
+        validateClusterName(descriptor);
+        validatePart("key()", descriptor.key(), descriptor);
+        validatePart("value()", descriptor.value(), descriptor);
+    }
+
+    private static void validateClusterName(final KafkaTopicDescriptor<?, ?> descriptor) {
+        final String cluster = requireNonBlank("cluster()", descriptor.cluster(), descriptor);
+
+        cluster.chars()
+                .filter(c -> !(Character.isDigit(c) || Character.isAlphabetic(c) || c == '-'))
+                .findFirst()
+                .ifPresent(
+                        c -> {
+                            throw new InvalidTopicDescriptorException(
+                                    "cluster() is invalid: illegal character '"
+                                            + (char) c
+                                            + "'. Only alpha-numerics and '-' are supported.",
+                                    descriptor);
+                        });
+    }
+
+    private static void validatePart(
+            final String name,
+            final KafkaTopicDescriptor.PartDescriptor<?> part,
+            final KafkaTopicDescriptor<?, ?> descriptor) {
+        requireNonNull(name, part, descriptor);
+        requireNonNull(name + ".type()", part.type(), descriptor);
+        requireNonNull(name + ".format()", part.format(), descriptor);
+    }
+
+    private static void requireNonNull(
+            final String name, final Object value, final KafkaTopicDescriptor<?, ?> descriptor) {
+        if (value == null) {
+            throw new InvalidTopicDescriptorException(name + " is null", descriptor);
+        }
+    }
+
+    private static String requireNonBlank(
+            final String name, final String value, final KafkaTopicDescriptor<?, ?> descriptor) {
+        requireNonNull(name, value, descriptor);
+        if (descriptor.name().isBlank()) {
+            throw new InvalidTopicDescriptorException(name + " is blank", descriptor);
+        }
+        return value;
+    }
+
+    private static final class InvalidTopicDescriptorException extends RuntimeException {
+        InvalidTopicDescriptorException(
+                final String msg, final KafkaTopicDescriptor<?, ?> descriptor) {
+            super(
+                    "Invalid topic descriptor: "
+                            + msg
+                            + System.lineSeparator()
+                            + KafkaTopicDescriptors.asString(descriptor));
+        }
+    }
+}

--- a/common/src/main/java/org/creekservice/internal/kafka/common/resource/KafkaTopicDescriptors.java
+++ b/common/src/main/java/org/creekservice/internal/kafka/common/resource/KafkaTopicDescriptors.java
@@ -80,8 +80,8 @@ public final class KafkaTopicDescriptors {
                 new StringJoiner(", ", topic.getClass().getSimpleName() + "[", "]")
                         .add("name=" + topic.name())
                         .add("cluster=" + topic.cluster())
-                        .add("key=" + asString(topic.key()))
-                        .add("value=" + asString(topic.value()));
+                        .add("key=" + (topic.key() == null ? "null" : asString(topic.key())))
+                        .add("value=" + (topic.value() == null ? "null" : asString(topic.value())));
 
         if (topic instanceof CreatableKafkaTopic) {
             final CreatableKafkaTopic<?, ?> owned = (CreatableKafkaTopic<?, ?>) topic;
@@ -121,7 +121,7 @@ public final class KafkaTopicDescriptors {
         final StringJoiner joiner =
                 new StringJoiner(", ", part.getClass().getSimpleName() + "[", "]")
                         .add("format=" + part.format())
-                        .add("type=" + part.type().getName());
+                        .add("type=" + (part.type() == null ? "null" : part.type().getName()));
 
         return joiner.toString();
     }

--- a/common/src/test/java/org/creekservice/api/kafka/common/config/ClustersPropertiesTest.java
+++ b/common/src/test/java/org/creekservice/api/kafka/common/config/ClustersPropertiesTest.java
@@ -49,6 +49,16 @@ class ClustersPropertiesTest {
     @Test
     void shouldImplementHashcodeAndEquals() {
         new EqualsTester()
+                // Builder:
+                .addEqualityGroup(
+                        propertiesBuilder().put("a", "b", "c").putCommon("d", "e"),
+                        propertiesBuilder().put("A", "b", "c").putCommon("d", "e"))
+                .addEqualityGroup(propertiesBuilder().put("diff", "b", "c").putCommon("d", "e"))
+                .addEqualityGroup(propertiesBuilder().put("a", "diff", "c").putCommon("d", "e"))
+                .addEqualityGroup(propertiesBuilder().put("a", "b", "diff").putCommon("d", "e"))
+                .addEqualityGroup(propertiesBuilder().put("a", "b", "c").putCommon("diff", "e"))
+                .addEqualityGroup(propertiesBuilder().put("a", "b", "c").putCommon("d", "diff"))
+                // Instance:
                 .addEqualityGroup(
                         propertiesBuilder().put("a", "b", "c").putCommon("d", "e").build(),
                         propertiesBuilder().put("a", "b", "c").putCommon("d", "e").build())
@@ -148,5 +158,29 @@ class ClustersPropertiesTest {
         // Then:
         final ClustersProperties props = builder.build();
         assertThat(props.get("c").get("k1"), is(1));
+    }
+
+    @Test
+    void shouldBeCaseInsensitiveOnClusterName() {
+        // Given:
+        final ClustersProperties props =
+                propertiesBuilder()
+                        .put("cluster", "k1", 1)
+                        .put("cluster", "k2", 1)
+                        .put("Cluster", "k1", 2)
+                        .build();
+
+        // Then:
+        assertThat(props.get("cLUSTer"), is(Map.of("k1", 2, "k2", 1)));
+    }
+
+    @Test
+    void shouldGetProperties() {
+        // Given:
+        final ClustersProperties props =
+                propertiesBuilder().putCommon("k1", 1).put("cluster", "k2", 2).build();
+
+        // Then:
+        assertThat(Map.copyOf(props.properties("cluster")), is(Map.of("k1", 1, "k2", 2)));
     }
 }

--- a/common/src/test/java/org/creekservice/api/kafka/common/config/SystemEnvPropertyOverridesTest.java
+++ b/common/src/test/java/org/creekservice/api/kafka/common/config/SystemEnvPropertyOverridesTest.java
@@ -18,12 +18,13 @@ package org.creekservice.api.kafka.common.config;
 
 import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+import static org.creekservice.api.kafka.common.config.ClustersProperties.propertiesBuilder;
 import static org.creekservice.api.kafka.common.config.SystemEnvPropertyOverrides.systemEnvPropertyOverrides;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import org.junitpioneer.jupiter.SetEnvironmentVariable.SetEnvironmentVariables;
@@ -31,40 +32,155 @@ import org.junitpioneer.jupiter.SetEnvironmentVariable.SetEnvironmentVariables;
 class SystemEnvPropertyOverridesTest {
 
     @Test
-    @SetEnvironmentVariables({
-        @SetEnvironmentVariable(key = "KAFKA_DEFAULT_BOOTSTRAP_SERVERS", value = "localhost:9092"),
-        @SetEnvironmentVariable(key = "KAFKA_DEFAULT_GROUP_ID", value = "a-group")
-    })
-    void shouldLoadPrefixedPropertiesFromEnvironment() {
+    void shouldSupportCommonKafkaProperties() {
+        // Given:
+        final SystemEnvPropertyOverrides provider =
+                new SystemEnvPropertyOverrides(
+                        Map.of(
+                                "KAFKA_BOOTSTRAP_SERVERS", "localhost:9092",
+                                "KAFKA_WHAT_EVER", "meh"));
+
         // When:
-        final ClustersProperties properties = systemEnvPropertyOverrides().get();
+        final ClustersProperties properties = provider.get(Set.of());
 
         // Then:
         assertThat(
-                properties.get("default"),
-                is(Map.of(BOOTSTRAP_SERVERS_CONFIG, "localhost:9092", GROUP_ID_CONFIG, "a-group")));
+                properties,
+                is(
+                        propertiesBuilder()
+                                .putCommon(BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+                                .putCommon("what.ever", "meh")
+                                .build()));
+    }
+
+    @Test
+    void shouldSupportSpecificKafkaProperties() {
+        // Given:
+        final SystemEnvPropertyOverrides provider =
+                new SystemEnvPropertyOverrides(
+                        Map.of(
+                                "KAFKA_CUSTOM_BOOTSTRAP_SERVERS", "localhost:9092",
+                                "KAFKA_CUSTOM_WHAT_EVER", "meh"));
+
+        // When:
+        final ClustersProperties properties = provider.get(Set.of("custom"));
+
+        // Then:
+        assertThat(
+                properties,
+                is(
+                        propertiesBuilder()
+                                .put("custom", BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+                                .put("custom", "what.ever", "meh")
+                                .build()));
+    }
+
+    @Test
+    void shouldSupportMultipleClusterNames() {
+        // Given:
+        final SystemEnvPropertyOverrides provider =
+                new SystemEnvPropertyOverrides(
+                        Map.of(
+                                "KAFKA_BOB_BOOTSTRAP_SERVERS", "localhost:9092",
+                                "KAFKA_JANE_WHAT_EVER", "meh",
+                                "KAFKA_WHAT_EVER", "ha"));
+
+        // When:
+        final ClustersProperties properties = provider.get(Set.of("jane", "bob"));
+
+        // Then:
+        assertThat(
+                properties,
+                is(
+                        propertiesBuilder()
+                                .put("bob", BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+                                .put("jane", "what.ever", "meh")
+                                .putCommon("what.ever", "ha")
+                                .build()));
+    }
+
+    @Test
+    void shouldFilterOutAnyThatMatchOtherPrefix() {
+        // Given:
+        final SystemEnvPropertyOverrides provider =
+                new SystemEnvPropertyOverrides(
+                        Map.of(
+                                "KAFKA_BOB_BOOTSTRAP_SERVERS", "localhost:9092",
+                                "KAFKA_BOB_TWO_WHAT_EVER", "meh"));
+
+        // When:
+        final ClustersProperties properties = provider.get(Set.of("bob", "bob-two"));
+
+        // Then:
+        assertThat(
+                properties,
+                is(
+                        propertiesBuilder()
+                                .put("bob", BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+                                .put("bob-two", "what.ever", "meh")
+                                .build()));
+    }
+
+    @Test
+    void shouldIgnoreEmptyPropertyNames() {
+        // Given:
+        final SystemEnvPropertyOverrides provider =
+                new SystemEnvPropertyOverrides(Map.of("KAFKA_", "blah", "KAFKA_SPECIFIC_", "blah"));
+
+        // When:
+        final ClustersProperties properties = provider.get(Set.of("specific"));
+
+        // Then:
+        assertThat(properties, is(propertiesBuilder().build()));
+    }
+
+    @Test
+    void shouldIgnoreNonPrefixedProperties() {
+        // Given:
+        final SystemEnvPropertyOverrides provider =
+                new SystemEnvPropertyOverrides(Map.of("NOT_KAFKA_PREFIXED", "blah"));
+
+        // When:
+        final ClustersProperties properties = provider.get(Set.of());
+
+        // Then:
+        assertThat(properties, is(propertiesBuilder().build()));
+    }
+
+    @Test
+    void shouldIgnoreBlankClusterName() {
+        // Given:
+        final SystemEnvPropertyOverrides provider =
+                new SystemEnvPropertyOverrides(
+                        Map.of("KAFKA_PROP", "v1", "KAFKA__WEIRD_PROP", "v2"));
+
+        // When:
+        final ClustersProperties properties = provider.get(Set.of());
+
+        // Then:
+        assertThat(
+                properties,
+                is(
+                        propertiesBuilder()
+                                .putCommon("prop", "v1")
+                                .putCommon(".weird.prop", "v2")
+                                .build()));
     }
 
     @Test
     @SetEnvironmentVariables({
-        @SetEnvironmentVariable(key = "KAFKA_BOB1_BOOTSTRAP_SERVERS", value = "localhost:9092"),
-        @SetEnvironmentVariable(key = "KAFKA_JANE29_GROUP_ID", value = "a-group")
+        @SetEnvironmentVariable(key = "KAFKA_CUSTOM_BOOTSTRAP_SERVERS", value = "localhost:9092"),
+        @SetEnvironmentVariable(key = "KAFKA_GROUP_ID", value = "a-group")
     })
-    void shouldSupportMultipleClusters() {
+    void shouldLoadPropertiesFromEnvironment() {
         // When:
-        final ClustersProperties properties = systemEnvPropertyOverrides().get();
+        final ClustersProperties properties = systemEnvPropertyOverrides().get(Set.of("Custom"));
 
         // Then:
-        assertThat(properties.get("bob1"), is(Map.of(BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")));
-        assertThat(properties.get("jane29"), is(Map.of(GROUP_ID_CONFIG, "a-group")));
-    }
+        assertThat(properties.get(""), is(Map.of(GROUP_ID_CONFIG, "a-group")));
 
-    @Test
-    @SetEnvironmentVariable(key = "NOT_KAFKA_PREFIXED", value = "whatever")
-    public void shouldIgnoreNonPrefixedProperties() {
-        final ClustersProperties properties = systemEnvPropertyOverrides().get();
-        assertThat(properties.get("not").entrySet(), is(empty()));
-        assertThat(properties.get("kafka").entrySet(), is(empty()));
-        assertThat(properties.get("prefixed").entrySet(), is(empty()));
+        assertThat(
+                properties.get("Custom"),
+                is(Map.of(BOOTSTRAP_SERVERS_CONFIG, "localhost:9092", GROUP_ID_CONFIG, "a-group")));
     }
 }

--- a/common/src/test/java/org/creekservice/internal/kafka/common/config/SystemEnvPropertiesTest.java
+++ b/common/src/test/java/org/creekservice/internal/kafka/common/config/SystemEnvPropertiesTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.common.config;
+
+import static org.creekservice.internal.kafka.common.config.SystemEnvProperties.propertyName;
+import static org.creekservice.internal.kafka.common.config.SystemEnvProperties.varName;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Optional;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.junit.jupiter.api.Test;
+
+class SystemEnvPropertiesTest {
+
+    @Test
+    void shouldRoundTripCommon() {
+        // Given:
+        final String clusterName = "";
+        final String propertyName = CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
+
+        // When:
+        final String varName = varName(propertyName, clusterName);
+        final Optional<String> result = propertyName(varName, clusterName);
+
+        // Then:
+        assertThat(result, is(Optional.of(propertyName)));
+        assertThat(varName, is("KAFKA_BOOTSTRAP_SERVERS"));
+    }
+
+    @Test
+    void shouldRoundTripSpecificCluster() {
+        // Given:
+        final String clusterName = "specific";
+        final String propertyName = CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
+
+        // When:
+        final String varName = varName(propertyName, clusterName);
+        final Optional<String> result = propertyName(varName, clusterName);
+
+        // Then:
+        assertThat(result, is(Optional.of(propertyName)));
+        assertThat(varName, is("KAFKA_SPECIFIC_BOOTSTRAP_SERVERS"));
+    }
+
+    @Test
+    void shouldHandleClusterNamesWithHyphens() {
+        // Given:
+        final String clusterName = "hyphenated-name";
+        final String propertyName = CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
+
+        // When:
+        final String varName = varName(propertyName, clusterName);
+        final Optional<String> result = propertyName(varName, clusterName);
+
+        // Then:
+        assertThat(result, is(Optional.of(propertyName)));
+        assertThat(varName, is("KAFKA_HYPHENATED_NAME_BOOTSTRAP_SERVERS"));
+    }
+
+    @Test
+    void shouldReturnEmptyIfNotPrefixed() {
+        assertThat(propertyName("NOT_KAFKA_PREFIXED", ""), is(Optional.empty()));
+        assertThat(propertyName("NOT_KAFKA_BOB_PREFIXED", "bob"), is(Optional.empty()));
+    }
+
+    @Test
+    void shouldReturnEmptyIfResultWouldBeEmptyPropertyName() {
+        assertThat(propertyName("KAFKA_", ""), is(Optional.empty()));
+        assertThat(propertyName("KAFKA_BOB_", "bob"), is(Optional.empty()));
+    }
+}

--- a/common/src/test/java/org/creekservice/internal/kafka/common/resource/KafkaResourceValidatorTest.java
+++ b/common/src/test/java/org/creekservice/internal/kafka/common/resource/KafkaResourceValidatorTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.common.resource;
+
+import static org.creekservice.api.kafka.metadata.SerializationFormat.serializationFormat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
+import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.PartDescriptor;
+import org.creekservice.api.kafka.metadata.SerializationFormat;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+import org.creekservice.api.platform.metadata.ResourceDescriptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class KafkaResourceValidatorTest {
+
+    private static final SerializationFormat SOME_FORMAT = serializationFormat("something");
+
+    @Mock private ComponentDescriptor componentA;
+    @Mock private ComponentDescriptor componentB;
+    @Mock private PartDescriptor<Long> topicKey;
+    @Mock private PartDescriptor<String> topicValue;
+    @Mock private KafkaTopicDescriptor<Long, String> topic;
+    private KafkaResourceValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        when(topicKey.type()).thenReturn(long.class);
+        when(topicKey.format()).thenReturn(SOME_FORMAT);
+
+        when(topicValue.type()).thenReturn(String.class);
+        when(topicValue.format()).thenReturn(SOME_FORMAT);
+
+        when(topic.name()).thenReturn("some-topic");
+        when(topic.cluster()).thenReturn(KafkaTopicDescriptor.DEFAULT_CLUSTER_NAME);
+        when(topic.key()).thenReturn(topicKey);
+        when(topic.value()).thenReturn(topicValue);
+
+        when(componentA.resources()).thenReturn(Stream.of(topic));
+
+        validator = new KafkaResourceValidator();
+    }
+
+    @Test
+    void shouldNotBlowUpIfNoKafkaResources() {
+        // Given:
+        final ResourceDescriptor otherResource = mock(ResourceDescriptor.class);
+        when(componentA.resources()).thenReturn(Stream.of(otherResource));
+
+        // When:
+        validator.validate(Stream.of(componentA));
+
+        // Then: did not blow up
+    }
+
+    @Test
+    void shouldThrowOnNullTopicName() {
+        // Given:
+        when(topic.name()).thenReturn(null);
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        RuntimeException.class, () -> validator.validate(Stream.of(componentA)));
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("Invalid topic descriptor: name() is null"));
+        assertThat(e.getMessage(), containsString(KafkaTopicDescriptors.asString(topic)));
+    }
+
+    @Test
+    void shouldThrowOnBlankTopicName() {
+        // Given:
+        when(topic.name()).thenReturn(" ");
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        RuntimeException.class, () -> validator.validate(Stream.of(componentA)));
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("Invalid topic descriptor: name() is blank"));
+        assertThat(e.getMessage(), containsString(KafkaTopicDescriptors.asString(topic)));
+    }
+
+    @Test
+    void shouldThrowOnNullClusterName() {
+        // Given:
+        when(topic.cluster()).thenReturn(null);
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        RuntimeException.class, () -> validator.validate(Stream.of(componentA)));
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("Invalid topic descriptor: cluster() is null"));
+        assertThat(e.getMessage(), containsString(KafkaTopicDescriptors.asString(topic)));
+    }
+
+    @Test
+    void shouldNotThrowOnBlankClusterName() {
+        // Given:
+        when(topic.cluster()).thenReturn("");
+
+        // When:
+        validator.validate(Stream.of(componentA));
+
+        // Then: did not throw.
+    }
+
+    @Test
+    void shouldThrowOnInvalidClusterName() {
+        // Given:
+        when(topic.cluster()).thenReturn("invalid_name");
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        RuntimeException.class, () -> validator.validate(Stream.of(componentA)));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                startsWith(
+                        "Invalid topic descriptor: cluster() is invalid: illegal character '_'. Only alpha-numerics and '-' are supported."));
+        assertThat(e.getMessage(), containsString(KafkaTopicDescriptors.asString(topic)));
+    }
+
+    @Test
+    void shouldThrowOnNullKey() {
+        // Given:
+        when(topic.key()).thenReturn(null);
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        RuntimeException.class, () -> validator.validate(Stream.of(componentA)));
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("Invalid topic descriptor: key() is null"));
+        assertThat(e.getMessage(), containsString(KafkaTopicDescriptors.asString(topic)));
+    }
+
+    @Test
+    void shouldThrowOnNullKeyType() {
+        // Given:
+        when(topicKey.type()).thenReturn(null);
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        RuntimeException.class, () -> validator.validate(Stream.of(componentA)));
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("Invalid topic descriptor: key().type() is null"));
+        assertThat(e.getMessage(), containsString(KafkaTopicDescriptors.asString(topic)));
+    }
+
+    @Test
+    void shouldThrowOnNullKeyFormat() {
+        // Given:
+        when(topicKey.format()).thenReturn(null);
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        RuntimeException.class, () -> validator.validate(Stream.of(componentA)));
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("Invalid topic descriptor: key().format() is null"));
+        assertThat(e.getMessage(), containsString(KafkaTopicDescriptors.asString(topic)));
+    }
+
+    @Test
+    void shouldThrowOnNullValue() {
+        // Given:
+        when(topic.value()).thenReturn(null);
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        RuntimeException.class, () -> validator.validate(Stream.of(componentA)));
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("Invalid topic descriptor: value() is null"));
+        assertThat(e.getMessage(), containsString(KafkaTopicDescriptors.asString(topic)));
+    }
+
+    @Test
+    void shouldThrowOnNullValueType() {
+        // Given:
+        when(topicValue.type()).thenReturn(null);
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        RuntimeException.class, () -> validator.validate(Stream.of(componentA)));
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("Invalid topic descriptor: value().type() is null"));
+        assertThat(e.getMessage(), containsString(KafkaTopicDescriptors.asString(topic)));
+    }
+
+    @Test
+    void shouldThrowOnNullValueFormat() {
+        // Given:
+        when(topicValue.format()).thenReturn(null);
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        RuntimeException.class, () -> validator.validate(Stream.of(componentA)));
+
+        // Then:
+        assertThat(
+                e.getMessage(), startsWith("Invalid topic descriptor: value().format() is null"));
+        assertThat(e.getMessage(), containsString(KafkaTopicDescriptors.asString(topic)));
+    }
+
+    @Test
+    void shouldCheckEachComponent() {
+        // Given:
+        when(componentA.resources()).thenReturn(Stream.of());
+        when(componentB.resources()).thenReturn(Stream.of(topic));
+        when(topicValue.type()).thenReturn(null);
+
+        // Then:
+        assertThrows(
+                RuntimeException.class,
+                () -> validator.validate(Stream.of(componentA, componentB)));
+    }
+}

--- a/common/src/test/java/org/creekservice/internal/kafka/common/resource/KafkaTopicDescriptorsTest.java
+++ b/common/src/test/java/org/creekservice/internal/kafka/common/resource/KafkaTopicDescriptorsTest.java
@@ -18,7 +18,9 @@ package org.creekservice.internal.kafka.common.resource;
 
 import static org.creekservice.api.kafka.metadata.SerializationFormat.serializationFormat;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
 
 import org.creekservice.api.kafka.metadata.CreatableKafkaTopic;
 import org.creekservice.api.kafka.metadata.KafkaTopicConfig;
@@ -338,7 +340,30 @@ class KafkaTopicDescriptorsTest {
                 };
 
         // Then:
-        assertThat(defaultDescriptor.cluster(), is("default"));
+        assertThat(defaultDescriptor.cluster(), is(KafkaTopicDescriptor.DEFAULT_CLUSTER_NAME));
+    }
+
+    @Test
+    void shouldNotBlowUpOnNulls() {
+        // Given:
+        final KafkaTopicDescriptor<?, ?> descriptor = mock(KafkaTopicDescriptor.class);
+
+        // Then:
+        assertThat(
+                KafkaTopicDescriptors.asString(descriptor),
+                containsString("[name=null, cluster=null, key=null, value=null]"));
+    }
+
+    @Test
+    void shouldNotBlowUpOnPartNulls() {
+        // Given:
+        final KafkaTopicDescriptor.PartDescriptor<?> descriptor =
+                mock(KafkaTopicDescriptor.PartDescriptor.class);
+
+        // Then:
+        assertThat(
+                KafkaTopicDescriptors.asString(descriptor),
+                containsString("[format=null, type=null]"));
     }
 
     private static final class FirstKafkaTopic<K, V> implements KafkaTopicDescriptor<K, V> {

--- a/common/src/test/java/org/creekservice/internal/kafka/common/resource/TopicCollectorTest.java
+++ b/common/src/test/java/org/creekservice/internal/kafka/common/resource/TopicCollectorTest.java
@@ -76,10 +76,12 @@ class TopicCollectorTest {
         when(creatableTopicValue.format()).thenReturn(SOME_FORMAT);
 
         when(topic.name()).thenReturn("topicDef");
+        when(topic.cluster()).thenReturn(KafkaTopicDescriptor.DEFAULT_CLUSTER_NAME);
         when(topic.key()).thenReturn(topicKey);
         when(topic.value()).thenReturn(topicValue);
 
         when(creatableTopic.name()).thenReturn("creatableTopicDef");
+        when(creatableTopic.cluster()).thenReturn(KafkaTopicDescriptor.DEFAULT_CLUSTER_NAME);
         when(creatableTopic.key()).thenReturn(creatableTopicKey);
         when(creatableTopic.value()).thenReturn(creatableTopicValue);
         when(creatableTopic.config()).thenReturn(() -> 0);

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/KafkaTopicDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/KafkaTopicDescriptor.java
@@ -37,7 +37,7 @@ public interface KafkaTopicDescriptor<K, V> extends ResourceDescriptor {
      *
      * <p>This name is used to look up connection details for the cluster.
      *
-     * <p>The name should be limited to alphanumeric characters.
+     * <p>The name should be limited to alphanumeric characters and hyphen {@code -}.
      *
      * @return the logical Kafka cluster name.
      */

--- a/streams-extension/README.md
+++ b/streams-extension/README.md
@@ -7,6 +7,8 @@ extension and use it to handle any topic resources.
 
 ## Configuration
 
+### Extension options
+
 The extension can be configured by passing an instance of [`KafkaStreamsExtensionOptions`][1] when creating
 the Creek context. For example,
 
@@ -33,6 +35,19 @@ public class ServiceMain {
 ```
 
 See [`KafkaStreamsExtensionOptions`][1] for more info.
+
+### System environment variables
+
+An alternative to using `KafkaStreamsExtensionOptions` to configure Kafka client properties is to use environment 
+variables. By default, any environment variable prefixed with `KAFKA_` will be passed to the Kafka clients.
+
+It is common to pass `bootstrap.servers` and authentication information to the service in this way, so that different
+values can be passed in different environments. For example, `bootstrap.servers` cam be passed by setting a
+`KAFKA_BOOTSTRAP_SERVERS` environment variable.
+
+See [`SystemEnvPropertyOverrides`][2] for more info, including multi-cluster support.
+
+This behaviour is customizable. See [`KafkaStreamsExtensionOptions`][1]`.withKafkaPropertiesOverrides` for more info.
 
 ## Building your topology
 
@@ -70,3 +85,4 @@ public final class TopologyBuilder {
 ```
 
 [1]: src/main/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtensionOptions.java
+[2]: ../common/src/main/java/org/creekservice/api/kafka/common/config/SystemEnvPropertyOverrides.java

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsBuilder.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsBuilder.java
@@ -24,26 +24,26 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.creekservice.api.base.annotation.VisibleForTesting;
-import org.creekservice.api.kafka.streams.extension.KafkaStreamsExtensionOptions;
+import org.creekservice.api.kafka.common.config.ClustersProperties;
 
 /** Builds a {@link KafkaStreams} app from a {@link Topology}. */
 public final class KafkaStreamsBuilder {
 
-    private final KafkaStreamsExtensionOptions options;
+    private final ClustersProperties clustersProperties;
     private final AppFactory appFactory;
 
-    public KafkaStreamsBuilder(final KafkaStreamsExtensionOptions options) {
-        this(options, KafkaStreams::new);
+    public KafkaStreamsBuilder(final ClustersProperties clustersProperties) {
+        this(clustersProperties, KafkaStreams::new);
     }
 
     @VisibleForTesting
-    KafkaStreamsBuilder(final KafkaStreamsExtensionOptions options, final AppFactory appFactory) {
-        this.options = requireNonNull(options, "options");
+    KafkaStreamsBuilder(final ClustersProperties clustersProperties, final AppFactory appFactory) {
+        this.clustersProperties = requireNonNull(clustersProperties, "clustersProperties");
         this.appFactory = requireNonNull(appFactory, "appFactory");
     }
 
     public KafkaStreams build(final Topology topology, final String clusterName) {
-        final Properties properties = options.properties(clusterName);
+        final Properties properties = clustersProperties.properties(clusterName);
         final KafkaClientSupplier kafkaClientSupplier = new DefaultKafkaClientSupplier();
 
         return appFactory.create(topology, properties, kafkaClientSupplier);

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsExtension.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsExtension.java
@@ -21,10 +21,10 @@ import static java.util.Objects.requireNonNull;
 import java.util.Properties;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
+import org.creekservice.api.kafka.common.config.ClustersProperties;
 import org.creekservice.api.kafka.common.resource.KafkaTopic;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
 import org.creekservice.api.kafka.streams.extension.KafkaStreamsExtension;
-import org.creekservice.api.kafka.streams.extension.KafkaStreamsExtensionOptions;
 import org.creekservice.internal.kafka.streams.extension.resource.ResourceRegistry;
 
 /** Kafka streams Creek extension. */
@@ -32,17 +32,17 @@ final class StreamsExtension implements KafkaStreamsExtension {
 
     static final String NAME = "Kafka-streams";
 
-    private final KafkaStreamsExtensionOptions options;
+    private final ClustersProperties clustersProperties;
     private final ResourceRegistry resources;
     private final KafkaStreamsBuilder appBuilder;
     private final KafkaStreamsExecutor appExecutor;
 
     StreamsExtension(
-            final KafkaStreamsExtensionOptions options,
+            final ClustersProperties clustersProperties,
             final ResourceRegistry resources,
             final KafkaStreamsBuilder appBuilder,
             final KafkaStreamsExecutor appExecutor) {
-        this.options = requireNonNull(options, "options");
+        this.clustersProperties = requireNonNull(clustersProperties, "clustersProperties");
         this.resources = requireNonNull(resources, "resources");
         this.appBuilder = requireNonNull(appBuilder, "appBuilder");
         this.appExecutor = requireNonNull(appExecutor, "appExecutor");
@@ -55,7 +55,7 @@ final class StreamsExtension implements KafkaStreamsExtension {
 
     @Override
     public Properties properties(final String clusterName) {
-        return options.properties(clusterName);
+        return clustersProperties.properties(clusterName);
     }
 
     @Override

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/config/ClustersPropertiesFactory.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/config/ClustersPropertiesFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.streams.extension.config;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.creekservice.api.base.annotation.VisibleForTesting;
+import org.creekservice.api.kafka.common.config.ClustersProperties;
+import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
+import org.creekservice.api.kafka.streams.extension.KafkaStreamsExtensionOptions;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+import org.creekservice.api.platform.metadata.ServiceDescriptor;
+
+public final class ClustersPropertiesFactory {
+
+    private final TopicCollector topicCollector;
+
+    public ClustersPropertiesFactory() {
+        this(org.creekservice.internal.kafka.common.resource.TopicCollector::collectTopics);
+    }
+
+    @VisibleForTesting
+    ClustersPropertiesFactory(final TopicCollector topicCollector) {
+        this.topicCollector = requireNonNull(topicCollector, "topicCollector");
+    }
+
+    public ClustersProperties create(
+            final ServiceDescriptor serviceDescriptor,
+            final KafkaStreamsExtensionOptions apiOptions) {
+
+        final Set<String> clusterNames =
+                topicCollector.collectTopics(List.of(serviceDescriptor)).values().stream()
+                        .map(KafkaTopicDescriptor::cluster)
+                        .collect(Collectors.toSet());
+
+        final ClustersProperties overrides = apiOptions.propertyOverrides().get(clusterNames);
+        return apiOptions.propertiesBuilder().putAll(overrides).build();
+    }
+
+    @VisibleForTesting
+    interface TopicCollector {
+        Map<String, KafkaTopicDescriptor<?, ?>> collectTopics(
+                Collection<? extends ComponentDescriptor> components);
+    }
+}

--- a/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtensionOptionsTest.java
+++ b/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtensionOptionsTest.java
@@ -16,23 +16,25 @@
 
 package org.creekservice.api.kafka.streams.extension;
 
-import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
-import static org.creekservice.api.kafka.common.config.ClustersProperties.propertiesBuilder;
-import static org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.DEFAULT_CLUSTER_NAME;
 import static org.creekservice.api.kafka.streams.extension.KafkaStreamsExtensionOptions.DEFAULT_STREAMS_CLOSE_TIMEOUT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
 import java.time.Duration;
+import java.util.Set;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.streams.StreamsConfig;
+import org.creekservice.api.kafka.common.config.KafkaPropertyOverrides;
+import org.creekservice.api.kafka.common.config.SystemEnvPropertyOverrides;
 import org.creekservice.api.kafka.streams.extension.exception.StreamsExceptionHandlers;
 import org.creekservice.api.kafka.streams.extension.observation.KafkaMetricsPublisherOptions;
 import org.creekservice.api.kafka.streams.extension.observation.LifecycleObserver;
@@ -41,7 +43,6 @@ import org.creekservice.internal.kafka.streams.extension.observation.DefaultLife
 import org.creekservice.internal.kafka.streams.extension.observation.DefaultStateRestoreObserver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 class KafkaStreamsExtensionOptionsTest {
 
@@ -65,16 +66,9 @@ class KafkaStreamsExtensionOptionsTest {
                 .addEqualityGroup(
                         KafkaStreamsExtensionOptions.builder()
                                 .withKafkaPropertiesOverrides(
-                                        () -> propertiesBuilder().put("default", "k", "v").build())
-                                .build(),
-                        KafkaStreamsExtensionOptions.builder()
-                                .withKafkaProperty("default", "k", "v")
+                                        (final Set<String> clusterNames) -> null)
                                 .build())
                 .addEqualityGroup(
-                        KafkaStreamsExtensionOptions.builder()
-                                .withKafkaPropertiesOverrides(
-                                        () -> propertiesBuilder().putCommon("k", "v").build())
-                                .build(),
                         KafkaStreamsExtensionOptions.builder().withKafkaProperty("k", "v").build())
                 .addEqualityGroup(
                         KafkaStreamsExtensionOptions.builder()
@@ -96,42 +90,77 @@ class KafkaStreamsExtensionOptionsTest {
     }
 
     @Test
+    void shouldThrowNPEs() {
+        final NullPointerTester tester =
+                new NullPointerTester().setDefault(String.class, "not empty");
+
+        tester.testAllPublicInstanceMethods(KafkaStreamsExtensionOptions.builder());
+        tester.testAllPublicInstanceMethods(KafkaStreamsExtensionOptions.builder().build());
+    }
+
+    @Test
     void shouldDefaultToEarliest() {
         assertThat(
-                builder.build().properties("any").get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG),
+                builder.build()
+                        .propertiesBuilder()
+                        .build()
+                        .get("any")
+                        .get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG),
                 is("earliest"));
     }
 
     @Test
     void shouldDefaultToAllAcks() {
-        assertThat(builder.build().properties("any").get(ProducerConfig.ACKS_CONFIG), is("all"));
+        assertThat(
+                builder.build()
+                        .propertiesBuilder()
+                        .build()
+                        .get("any")
+                        .get(ProducerConfig.ACKS_CONFIG),
+                is("all"));
     }
 
     @Test
     void shouldDefaultToSnappyCompression() {
         assertThat(
-                builder.build().properties("any").get(ProducerConfig.COMPRESSION_TYPE_CONFIG),
+                builder.build()
+                        .propertiesBuilder()
+                        .build()
+                        .get("any")
+                        .get(ProducerConfig.COMPRESSION_TYPE_CONFIG),
                 is("snappy"));
     }
 
     @Test
     void shouldDefaultToThreeReplicasForInternalStreamsTopics() {
         assertThat(
-                builder.build().properties("any").get(StreamsConfig.REPLICATION_FACTOR_CONFIG),
+                builder.build()
+                        .propertiesBuilder()
+                        .build()
+                        .get("any")
+                        .get(StreamsConfig.REPLICATION_FACTOR_CONFIG),
                 is(3));
     }
 
     @Test
     void shouldDefaultToExactlyOnce() {
         assertThat(
-                builder.build().properties("any").get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG),
+                builder.build()
+                        .propertiesBuilder()
+                        .build()
+                        .get("any")
+                        .get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG),
                 is(StreamsConfig.EXACTLY_ONCE_BETA));
     }
 
     @Test
     void shouldDefaultToCommitInterval() {
         assertThat(
-                builder.build().properties("any").get(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG),
+                builder.build()
+                        .propertiesBuilder()
+                        .build()
+                        .get("any")
+                        .get(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG),
                 is(1000));
     }
 
@@ -139,102 +168,55 @@ class KafkaStreamsExtensionOptionsTest {
     void shouldDefaultExceptionHandler() {
         assertThat(
                 builder.build()
-                        .properties("any")
+                        .propertiesBuilder()
+                        .build()
+                        .get("any")
                         .get(StreamsConfig.DEFAULT_PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG),
                 is(StreamsExceptionHandlers.LogAndFailProductionExceptionHandler.class));
     }
 
     @Test
-    @SetEnvironmentVariable.SetEnvironmentVariables({
-        @SetEnvironmentVariable(key = "KAFKA_DEFAULT_BOOTSTRAP_SERVERS", value = "localhost:9092"),
-        @SetEnvironmentVariable(key = "KAFKA_OTHER_ACKS", value = "1")
-    })
     void shouldLoadKafkaPropertyOverridesFromTheEnvironmentByDefault() {
         // When:
         final KafkaStreamsExtensionOptions options = builder.build();
 
         // Then:
-        assertThat(
-                options.properties(DEFAULT_CLUSTER_NAME),
-                hasEntry(BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"));
-        assertThat(options.properties("other"), hasEntry(ProducerConfig.ACKS_CONFIG, "1"));
+        assertThat(options.propertyOverrides(), is(instanceOf(SystemEnvPropertyOverrides.class)));
     }
 
     @Test
     void shouldLoadKafkaPropertyOverridesFromAlternateProvider() {
         // Given:
-        builder.withKafkaPropertiesOverrides(
-                () -> propertiesBuilder().put("bob", "name", "value").build());
+        final KafkaPropertyOverrides overridesProvider = mock(KafkaPropertyOverrides.class);
 
         // When:
-        final KafkaStreamsExtensionOptions options = builder.build();
+        builder.withKafkaPropertiesOverrides(overridesProvider);
 
         // Then:
-        assertThat(options.properties("bob"), hasEntry("name", "value"));
+        assertThat(builder.build().propertyOverrides(), is(sameInstance(overridesProvider)));
     }
 
     @Test
     void shouldSetKafkaProperty() {
-        // Given:
+        // When:
         builder.withKafkaProperty("name", "value");
 
-        // When:
-        final KafkaStreamsExtensionOptions options = builder.build();
-
         // Then:
-        assertThat(options.properties(DEFAULT_CLUSTER_NAME), hasEntry("name", "value"));
+        assertThat(
+                builder.build().propertiesBuilder().build().get("any"), hasEntry("name", "value"));
     }
 
     @Test
     void shouldSetKafkaPropertyForSpecificCluster() {
-        // Given:
+        // When:
         builder.withKafkaProperty("bob", "name", "value");
-
-        // When:
-        final KafkaStreamsExtensionOptions options = builder.build();
-
-        // Then:
-        assertThat(options.properties("bob"), hasEntry("name", "value"));
-    }
-
-    @Test
-    void shouldExposeKafkaPropertiesAsMap() {
-        // Given:
-        builder.withKafkaProperty("name", "value");
-
-        // When:
-        final KafkaStreamsExtensionOptions options = builder.build();
-
-        // Then:
-        assertThat(options.propertyMap(DEFAULT_CLUSTER_NAME), hasEntry("name", "value"));
-    }
-
-    @Test
-    @SetEnvironmentVariable(key = "KAFKA_DEFAULT_BOOTSTRAP_SERVERS", value = "localhost:9092")
-    void shouldOverrideSetKafkaProperties() {
-        // Given:
-        builder.withKafkaProperty(BOOTSTRAP_SERVERS_CONFIG, "wrong!");
-
-        // When:
-        final KafkaStreamsExtensionOptions options = builder.build();
 
         // Then:
         assertThat(
-                options.properties(DEFAULT_CLUSTER_NAME),
-                hasEntry(BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"));
-    }
-
-    @Test
-    void shouldNotExposeMutableProperties() {
-        // Given:
-        builder.withKafkaProperty("name", "value");
-        final KafkaStreamsExtensionOptions options = builder.build();
-
-        // When:
-        options.properties(DEFAULT_CLUSTER_NAME).put("mutate", 10);
-
-        // Then:
-        assertThat(options.properties(DEFAULT_CLUSTER_NAME), not(hasKey("mutate")));
+                builder.build().propertiesBuilder().build().get("bob"), hasEntry("name", "value"));
+        assertThat(
+                builder.build().propertiesBuilder().build().get("any"),
+                not(hasEntry("name", "value")));
     }
 
     @Test

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsBuilderTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsBuilderTest.java
@@ -28,7 +28,7 @@ import java.util.Properties;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
-import org.creekservice.api.kafka.streams.extension.KafkaStreamsExtensionOptions;
+import org.creekservice.api.kafka.common.config.ClustersProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,17 +40,17 @@ class KafkaStreamsBuilderTest {
 
     @Mock private KafkaStreamsBuilder.AppFactory appFactory;
     @Mock private KafkaStreams app;
-    @Mock private KafkaStreamsExtensionOptions options;
+    @Mock private ClustersProperties clustersProperties;
     @Mock private Properties properties;
     @Mock private Topology topology;
     private KafkaStreamsBuilder builder;
 
     @BeforeEach
     void setUp() {
-        builder = new KafkaStreamsBuilder(options, appFactory);
+        builder = new KafkaStreamsBuilder(clustersProperties, appFactory);
 
         when(appFactory.create(any(), any(), any())).thenReturn(app);
-        when(options.properties(any())).thenReturn(properties);
+        when(clustersProperties.properties(any())).thenReturn(properties);
     }
 
     @Test
@@ -59,7 +59,7 @@ class KafkaStreamsBuilderTest {
         builder.build(topology, "cluster");
 
         // Then:
-        verify(options).properties("cluster");
+        verify(clustersProperties).properties("cluster");
     }
 
     @Test

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsExtensionProviderTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsExtensionProviderTest.java
@@ -17,29 +17,43 @@
 package org.creekservice.internal.kafka.streams.extension;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
+import org.creekservice.api.kafka.common.config.ClustersProperties;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
 import org.creekservice.api.kafka.streams.extension.KafkaStreamsExtensionOptions;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
 import org.creekservice.api.platform.metadata.ServiceDescriptor;
 import org.creekservice.api.service.extension.CreekService;
 import org.creekservice.api.service.extension.model.ModelContainer;
 import org.creekservice.api.service.extension.option.OptionCollection;
+import org.creekservice.internal.kafka.common.resource.KafkaResourceValidator;
+import org.creekservice.internal.kafka.streams.extension.config.ClustersPropertiesFactory;
 import org.creekservice.internal.kafka.streams.extension.resource.ResourceRegistry;
 import org.creekservice.internal.kafka.streams.extension.resource.ResourceRegistryFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.mockito.stubbing.Answer;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -47,12 +61,15 @@ class KafkaStreamsExtensionProviderTest {
 
     public static final KafkaStreamsExtensionOptions DEFAULT_OPTIONS =
             KafkaStreamsExtensionOptions.builder().build();
-    private KafkaStreamsExtensionProvider provider;
+
+    @Mock private KafkaResourceValidator resourceValidator;
     @Mock private ServiceDescriptor component;
     @Mock private KafkaStreamsExtensionOptions userOptions;
+    @Mock private ClustersPropertiesFactory propertiesFactory;
     @Mock private KafkaStreamsExtensionProvider.BuilderFactory builderFactory;
     @Mock private KafkaStreamsExtensionProvider.ExecutorFactory executorFactory;
     @Mock private KafkaStreamsExtensionProvider.ExtensionFactory extensionFactory;
+    @Mock private ClustersProperties clustersProperties;
     @Mock private ResourceRegistryFactory resourceFactory;
     @Mock private KafkaStreamsBuilder streamsBuilder;
     @Mock private KafkaStreamsExecutor streamsExecutor;
@@ -61,13 +78,24 @@ class KafkaStreamsExtensionProviderTest {
     @Mock private CreekService api;
     @Mock private OptionCollection options;
     @Mock private ModelContainer model;
+    private final List<ComponentDescriptor> validatedComponents = new ArrayList<>();
+
+    private KafkaStreamsExtensionProvider provider;
 
     @BeforeEach
     void setUp() {
+        validatedComponents.clear();
+
         provider =
                 new KafkaStreamsExtensionProvider(
-                        builderFactory, executorFactory, extensionFactory, resourceFactory);
+                        resourceValidator,
+                        propertiesFactory,
+                        builderFactory,
+                        executorFactory,
+                        extensionFactory,
+                        resourceFactory);
 
+        when(propertiesFactory.create(any(), any())).thenReturn(clustersProperties);
         when(builderFactory.create(any())).thenReturn(streamsBuilder);
         when(executorFactory.create(any())).thenReturn(streamsExecutor);
         when(resourceFactory.create(any(), any())).thenReturn(resources);
@@ -76,6 +104,52 @@ class KafkaStreamsExtensionProviderTest {
         when(api.options()).thenReturn(options);
         when(api.model()).thenReturn(model);
         when(api.service()).thenReturn(component);
+    }
+
+    @Test
+    void shouldValidateResources() {
+        // Given:
+        doAnswer(trackValidatedComponents()).when(resourceValidator).validate(any());
+
+        // When:
+        provider.initialize(api);
+
+        // Then:
+        assertThat(validatedComponents, contains(component));
+    }
+
+    @Test
+    void shouldValidateResourcesFirst() {
+        // When:
+        provider.initialize(api);
+
+        // Then:
+        final InOrder inOrder =
+                inOrder(
+                        resourceValidator,
+                        propertiesFactory,
+                        builderFactory,
+                        executorFactory,
+                        resourceFactory);
+        inOrder.verify(resourceValidator).validate(any());
+        inOrder.verify(propertiesFactory).create(any(), any());
+        inOrder.verify(resourceFactory).create(any(), any());
+        inOrder.verify(builderFactory).create(any());
+        inOrder.verify(executorFactory).create(any());
+    }
+
+    @Test
+    void shouldThrowIfValidatorThrows() {
+        // Given:
+        final IllegalArgumentException cause = new IllegalArgumentException("Boom");
+        doThrow(cause).when(resourceValidator).validate(any());
+
+        // When:
+        final Exception e =
+                assertThrows(IllegalArgumentException.class, () -> provider.initialize(api));
+
+        // Then:
+        assertThat(e, is(sameInstance(cause)));
     }
 
     @Test
@@ -88,16 +162,16 @@ class KafkaStreamsExtensionProviderTest {
     }
 
     @Test
-    void shouldBuildStreamsBuilderWithDefaultOptions() {
+    void shouldBuildClustersPropertiesWithDefaultOptions() {
         // When:
         provider.initialize(api);
 
         // Then:
-        verify(builderFactory).create(DEFAULT_OPTIONS);
+        verify(propertiesFactory).create(component, DEFAULT_OPTIONS);
     }
 
     @Test
-    void shouldBuildStreamsBuilderWithUserOptions() {
+    void shouldBuildClustersPropertiesWithWithUserOptions() {
         // Given:
         when(options.get(KafkaStreamsExtensionOptions.class)).thenReturn(Optional.of(userOptions));
 
@@ -105,28 +179,25 @@ class KafkaStreamsExtensionProviderTest {
         provider.initialize(api);
 
         // Then:
-        verify(builderFactory).create(userOptions);
+        verify(propertiesFactory).create(component, userOptions);
     }
 
     @Test
-    void shouldBuildResourcesWithDefaultOptions() {
+    void shouldBuildStreamsBuilder() {
         // When:
         provider.initialize(api);
 
         // Then:
-        verify(resourceFactory).create(component, DEFAULT_OPTIONS);
+        verify(builderFactory).create(clustersProperties);
     }
 
     @Test
-    void shouldBuildResourcesWithUserOptions() {
-        // Given:
-        when(options.get(KafkaStreamsExtensionOptions.class)).thenReturn(Optional.of(userOptions));
-
+    void shouldBuildResources() {
         // When:
         provider.initialize(api);
 
         // Then:
-        verify(resourceFactory).create(component, userOptions);
+        verify(resourceFactory).create(component, clustersProperties);
     }
 
     @Test
@@ -151,25 +222,13 @@ class KafkaStreamsExtensionProviderTest {
     }
 
     @Test
-    void shouldBuildExtensionWithDefaultOptions() {
+    void shouldBuildExtension() {
         // When:
         provider.initialize(api);
 
         // Then:
         verify(extensionFactory)
-                .create(DEFAULT_OPTIONS, resources, streamsBuilder, streamsExecutor);
-    }
-
-    @Test
-    void shouldBuildExtensionWithUserOptions() {
-        // Given:
-        when(options.get(KafkaStreamsExtensionOptions.class)).thenReturn(Optional.of(userOptions));
-
-        // When:
-        provider.initialize(api);
-
-        // Then:
-        verify(extensionFactory).create(userOptions, resources, streamsBuilder, streamsExecutor);
+                .create(clustersProperties, resources, streamsBuilder, streamsExecutor);
     }
 
     @Test
@@ -179,5 +238,13 @@ class KafkaStreamsExtensionProviderTest {
 
         // Then:
         assertThat(result, is(sameInstance(streamsExtension)));
+    }
+
+    private Answer<Void> trackValidatedComponents() {
+        return inv -> {
+            final Stream<? extends ComponentDescriptor> s = inv.getArgument(0);
+            s.forEachOrdered(validatedComponents::add);
+            return null;
+        };
     }
 }

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsExtensionTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsExtensionTest.java
@@ -26,9 +26,9 @@ import static org.mockito.Mockito.when;
 import java.util.Properties;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
+import org.creekservice.api.kafka.common.config.ClustersProperties;
 import org.creekservice.api.kafka.common.resource.KafkaTopic;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
-import org.creekservice.api.kafka.streams.extension.KafkaStreamsExtensionOptions;
 import org.creekservice.internal.kafka.streams.extension.resource.ResourceRegistry;
 import org.creekservice.internal.kafka.streams.extension.resource.Topic;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,7 +43,7 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class StreamsExtensionTest {
 
-    @Mock private KafkaStreamsExtensionOptions options;
+    @Mock private ClustersProperties clustersProperties;
     @Mock private ResourceRegistry resources;
     @Mock private KafkaStreamsBuilder builder;
     @Mock private KafkaStreamsExecutor executor;
@@ -56,9 +56,9 @@ class StreamsExtensionTest {
 
     @BeforeEach
     void setUp() {
-        extension = new StreamsExtension(options, resources, builder, executor);
+        extension = new StreamsExtension(clustersProperties, resources, builder, executor);
 
-        when(options.properties(any())).thenReturn(properties);
+        when(clustersProperties.properties(any())).thenReturn(properties);
         when(builder.build(any(), any())).thenReturn(app);
     }
 
@@ -74,7 +74,7 @@ class StreamsExtensionTest {
 
         // Then:
         assertThat(result, is(properties));
-        verify(options).properties("cluster-bob");
+        verify(clustersProperties).properties("cluster-bob");
     }
 
     @Test

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/config/ClustersPropertiesFactoryTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/config/ClustersPropertiesFactoryTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.streams.extension.config;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.creekservice.api.kafka.common.config.ClustersProperties;
+import org.creekservice.api.kafka.common.config.KafkaPropertyOverrides;
+import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
+import org.creekservice.api.kafka.streams.extension.KafkaStreamsExtensionOptions;
+import org.creekservice.api.platform.metadata.ServiceDescriptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClustersPropertiesFactoryTest {
+
+    @Mock private ClustersPropertiesFactory.TopicCollector topicCollector;
+    @Mock private ServiceDescriptor serviceDescriptor;
+    @Mock private ClustersProperties.Builder propertiesBuilder;
+    @Mock private ClustersProperties.Builder updatedPropertiesBuilder;
+    @Mock private KafkaPropertyOverrides propertiesOverrides;
+    @Mock private ClustersProperties propertyOverrides;
+    @Mock private KafkaStreamsExtensionOptions options;
+    @Mock private KafkaTopicDescriptor<?, ?> topicA;
+    @Mock private KafkaTopicDescriptor<?, ?> topicB;
+    @Mock private ClustersProperties buildProperties;
+    private ClustersPropertiesFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new ClustersPropertiesFactory(topicCollector);
+
+        when(options.propertiesBuilder()).thenReturn(propertiesBuilder);
+        when(options.propertyOverrides()).thenReturn(propertiesOverrides);
+
+        when(topicCollector.collectTopics(List.of(serviceDescriptor)))
+                .thenReturn(Map.of("a", topicA, "b", topicB));
+
+        when(topicA.cluster()).thenReturn("cluster-A");
+        when(topicB.cluster()).thenReturn("cluster-B");
+
+        when(propertiesOverrides.get(anySet())).thenReturn(propertyOverrides);
+        when(propertiesBuilder.putAll(any())).thenReturn(updatedPropertiesBuilder);
+        when(updatedPropertiesBuilder.build()).thenReturn(buildProperties);
+    }
+
+    @Test
+    void shouldPassClusterNamesToOverridesProvider() {
+        // When:
+        factory.create(serviceDescriptor, options);
+
+        // Then:
+        verify(propertiesOverrides).get(Set.of("cluster-A", "cluster-B"));
+    }
+
+    @Test
+    void shouldPassUniqueClusterNamesToOverridesProvider() {
+        // Given:
+        when(topicB.cluster()).thenReturn("cluster-A");
+
+        // When:
+        factory.create(serviceDescriptor, options);
+
+        // Then:
+        verify(propertiesOverrides).get(Set.of("cluster-A"));
+    }
+
+    @Test
+    void shouldApplyOverridesToProperties() {
+        // When:
+        factory.create(serviceDescriptor, options);
+
+        // Then:
+        verify(propertiesBuilder).putAll(propertyOverrides);
+    }
+
+    @Test
+    void shouldReturnProperties() {
+        // When:
+        final ClustersProperties result = factory.create(serviceDescriptor, options);
+
+        // Then:
+        assertThat(result, is(buildProperties));
+    }
+}

--- a/streams-test/src/test/java/org/creekservice/api/kafka/streams/test/TestKafkaStreamsExtensionOptionsTest.java
+++ b/streams-test/src/test/java/org/creekservice/api/kafka/streams/test/TestKafkaStreamsExtensionOptionsTest.java
@@ -31,7 +31,9 @@ class TestKafkaStreamsExtensionOptionsTest {
         // When:
         final Object stateDir =
                 TestKafkaStreamsExtensionOptions.defaults()
-                        .properties("any")
+                        .propertiesBuilder()
+                        .build()
+                        .get("any")
                         .get(StreamsConfig.STATE_DIR_CONFIG);
 
         // Then:

--- a/test-extension/build.gradle.kts
+++ b/test-extension/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     api(project(":metadata"))
     api("org.creekservice:creek-system-test-extension:$creekSystemTestVersion")
 
+    implementation(project(":common"))
     implementation("org.creekservice:creek-base-type:$creekBaseVersion")
 
     testImplementation(project(":test-service"))

--- a/test-extension/src/main/java/module-info.java
+++ b/test-extension/src/main/java/module-info.java
@@ -16,7 +16,7 @@
 
 
 import org.creekservice.api.system.test.extension.CreekTestExtension;
-import org.creekservice.internal.kafka.streams.test.extension.KafkaStreamsTestExtension;
+import org.creekservice.internal.kafka.streams.test.extension.KafkaTestExtension;
 
 module creek.kafka.streams.test.extension {
     requires transitive creek.system.test.extension;
@@ -25,5 +25,5 @@ module creek.kafka.streams.test.extension {
     requires creek.kafka.common;
 
     provides CreekTestExtension with
-            KafkaStreamsTestExtension;
+            KafkaTestExtension;
 }

--- a/test-extension/src/main/java/module-info.java
+++ b/test-extension/src/main/java/module-info.java
@@ -22,6 +22,7 @@ module creek.kafka.streams.test.extension {
     requires transitive creek.system.test.extension;
     requires creek.kafka.metadata;
     requires creek.base.type;
+    requires creek.kafka.common;
 
     provides CreekTestExtension with
             KafkaStreamsTestExtension;

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/KafkaStreamsTestExtension.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/KafkaStreamsTestExtension.java
@@ -19,7 +19,9 @@ package org.creekservice.internal.kafka.streams.test.extension;
 
 import org.creekservice.api.system.test.extension.CreekSystemTest;
 import org.creekservice.api.system.test.extension.CreekTestExtension;
+import org.creekservice.api.system.test.extension.testsuite.TestListenerContainer;
 import org.creekservice.internal.kafka.streams.test.extension.testsuite.StreamsTestLifecycleListener;
+import org.creekservice.internal.kafka.streams.test.extension.testsuite.ValidatingTestListener;
 
 /**
  * A Creek system test extension for testing Kafka Streams based microservices.
@@ -35,6 +37,8 @@ public final class KafkaStreamsTestExtension implements CreekTestExtension {
 
     @Override
     public void initialize(final CreekSystemTest systemTest) {
-        systemTest.testSuite().listener().append(new StreamsTestLifecycleListener(systemTest));
+        final TestListenerContainer testListeners = systemTest.testSuite().listener();
+        testListeners.append(new ValidatingTestListener(systemTest));
+        testListeners.append(new StreamsTestLifecycleListener(systemTest));
     }
 }

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtension.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtension.java
@@ -29,10 +29,10 @@ import org.creekservice.internal.kafka.streams.test.extension.testsuite.Validati
  * <p>The extension will start any required Kafka clusters and handle any Kafka related inputs and
  * expectations defined in system tests.
  */
-public final class KafkaStreamsTestExtension implements CreekTestExtension {
+public final class KafkaTestExtension implements CreekTestExtension {
     @Override
     public String name() {
-        return "creek-kafka-streams";
+        return "creek-kafka";
     }
 
     @Override

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDef.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDef.java
@@ -38,7 +38,10 @@ final class KafkaContainerDef implements ServiceDefinition {
     private final String name;
 
     KafkaContainerDef(final String clusterName) {
-        this.name = "kafka-" + requireNonNull(clusterName, "clusterName");
+        this.name =
+                requireNonNull(clusterName, "clusterName").isBlank()
+                        ? "kafka"
+                        : "kafka-" + clusterName;
     }
 
     @Override

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/ValidatingTestListener.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/ValidatingTestListener.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.streams.test.extension.testsuite;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.creekservice.api.base.annotation.VisibleForTesting;
+import org.creekservice.api.platform.metadata.ServiceDescriptor;
+import org.creekservice.api.system.test.extension.CreekSystemTest;
+import org.creekservice.api.system.test.extension.model.CreekTestSuite;
+import org.creekservice.api.system.test.extension.service.ServiceInstance;
+import org.creekservice.api.system.test.extension.testsuite.TestLifecycleListener;
+import org.creekservice.internal.kafka.common.resource.KafkaResourceValidator;
+
+public final class ValidatingTestListener implements TestLifecycleListener {
+
+    private final CreekSystemTest api;
+    private final KafkaResourceValidator validator;
+
+    public ValidatingTestListener(final CreekSystemTest api) {
+        this(api, new KafkaResourceValidator());
+    }
+
+    @VisibleForTesting
+    ValidatingTestListener(final CreekSystemTest api, final KafkaResourceValidator validator) {
+        this.api = requireNonNull(api, "api");
+        this.validator = requireNonNull(validator, "validator");
+    }
+
+    @Override
+    public void beforeSuite(final CreekTestSuite suite) {
+        final Stream<ServiceDescriptor> descriptors =
+                api.testSuite().services().stream()
+                        .map(ServiceInstance::descriptor)
+                        .flatMap(Optional::stream);
+
+        validator.validate(descriptors);
+    }
+}

--- a/test-extension/src/main/resources/META-INF/services/org.creekservice.api.system.test.extension.CreekTestExtension
+++ b/test-extension/src/main/resources/META-INF/services/org.creekservice.api.system.test.extension.CreekTestExtension
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-org.creekservice.internal.kafka.streams.test.extension.KafkaStreamsTestExtension
+org.creekservice.internal.kafka.streams.test.extension.KafkaTestExtension

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/KafkaStreamsTestExtensionTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/KafkaStreamsTestExtensionTest.java
@@ -23,13 +23,16 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 
 import org.creekservice.api.system.test.extension.CreekSystemTest;
 import org.creekservice.internal.kafka.streams.test.extension.testsuite.StreamsTestLifecycleListener;
+import org.creekservice.internal.kafka.streams.test.extension.testsuite.ValidatingTestListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -56,6 +59,17 @@ class KafkaStreamsTestExtensionTest {
     @Test
     void shouldExposeName() {
         assertThat(ext.name(), is("creek-kafka-streams"));
+    }
+
+    @Test
+    void shouldAppendValidatingListenerBeforeMainListener() {
+        // When:
+        ext.initialize(api);
+
+        // Then:
+        final InOrder inOrder = inOrder(api.testSuite().listener());
+        inOrder.verify(api.testSuite().listener()).append(isA(ValidatingTestListener.class));
+        inOrder.verify(api.testSuite().listener()).append(isA(StreamsTestLifecycleListener.class));
     }
 
     @Test

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtensionTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtensionTest.java
@@ -37,28 +37,28 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class KafkaStreamsTestExtensionTest {
+class KafkaTestExtensionTest {
 
     @Mock(answer = RETURNS_DEEP_STUBS)
     private CreekSystemTest api;
 
-    private KafkaStreamsTestExtension ext;
+    private KafkaTestExtension ext;
 
     @BeforeEach
     void setUp() {
-        ext = new KafkaStreamsTestExtension();
+        ext = new KafkaTestExtension();
     }
 
     @Test
     void shouldExposeExtension() {
         assertThat(
                 extensionTester().accessibleExtensions(),
-                hasItem(instanceOf(KafkaStreamsTestExtension.class)));
+                hasItem(instanceOf(KafkaTestExtension.class)));
     }
 
     @Test
     void shouldExposeName() {
-        assertThat(ext.name(), is("creek-kafka-streams"));
+        assertThat(ext.name(), is("creek-kafka"));
     }
 
     @Test

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDefTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDefTest.java
@@ -17,6 +17,7 @@
 package org.creekservice.internal.kafka.streams.test.extension.testsuite;
 
 import static java.lang.System.lineSeparator;
+import static org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.DEFAULT_CLUSTER_NAME;
 import static org.creekservice.api.system.test.extension.service.ServiceInstance.ExecResult.execResult;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -73,6 +74,15 @@ class KafkaContainerDefTest {
     @Test
     void shouldExposeName() {
         assertThat(def.name(), is("kafka-bob"));
+    }
+
+    @Test
+    void shouldSupportDefaultName() {
+        // Given:
+        def = new KafkaContainerDef(DEFAULT_CLUSTER_NAME);
+
+        // Then:
+        assertThat(def.name(), is("kafka-default"));
     }
 
     @Test

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/ValidatingTestListenerTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/ValidatingTestListenerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.streams.test.extension.testsuite;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.mockito.quality.Strictness.LENIENT;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+import org.creekservice.api.platform.metadata.ServiceDescriptor;
+import org.creekservice.api.system.test.extension.CreekSystemTest;
+import org.creekservice.api.system.test.extension.service.ConfigurableServiceInstance;
+import org.creekservice.internal.kafka.common.resource.KafkaResourceValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.stubbing.Answer;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = LENIENT)
+class ValidatingTestListenerTest {
+
+    @Mock(answer = RETURNS_DEEP_STUBS)
+    private CreekSystemTest api;
+
+    @Mock private ConfigurableServiceInstance inst0;
+    @Mock private ConfigurableServiceInstance inst1;
+    @Mock private ServiceDescriptor descriptor0;
+    @Mock private ServiceDescriptor descriptor1;
+    @Mock private KafkaResourceValidator validator;
+    private final List<ComponentDescriptor> validatedComponents = new ArrayList<>();
+    private ValidatingTestListener listener;
+
+    @BeforeEach
+    void setUp() {
+        validatedComponents.clear();
+
+        listener = new ValidatingTestListener(api, validator);
+
+        when(api.testSuite().services().stream()).thenReturn(Stream.of(inst0, inst1));
+        when(inst0.descriptor()).thenReturn(Optional.of(descriptor0));
+        when(inst1.descriptor()).thenReturn(Optional.of(descriptor1));
+        doAnswer(trackValidatedComponents()).when(validator).validate(any());
+    }
+
+    @Test
+    void shouldValidateServiceDescriptors() {
+        // When:
+        listener.beforeSuite(null);
+
+        // Then:
+        assertThat(validatedComponents, contains(descriptor0, descriptor1));
+    }
+
+    @Test
+    void shouldIgnoreServicesWithOutDescriptors() {
+        // Given:
+        when(inst0.descriptor()).thenReturn(Optional.empty());
+
+        // When:
+        listener.beforeSuite(null);
+
+        // Then:
+        assertThat(validatedComponents, contains(descriptor1));
+    }
+
+    @Test
+    void shouldThrowOnInvalidDescriptor() {
+        // Given:
+        final IllegalArgumentException cause = new IllegalArgumentException("BOOM");
+        doThrow(cause).when(validator).validate(any());
+
+        // When:
+        final Exception e =
+                assertThrows(IllegalArgumentException.class, () -> listener.beforeSuite(null));
+
+        // Then:
+        assertThat(e, is(sameInstance(cause)));
+    }
+
+    private Answer<Void> trackValidatedComponents() {
+        return inv -> {
+            final Stream<? extends ComponentDescriptor> s = inv.getArgument(0);
+            s.forEachOrdered(validatedComponents::add);
+            return null;
+        };
+    }
+}


### PR DESCRIPTION
The set of Kafka cluster names is known, (by inspecting the service descriptors), and can be used to more intelligently extract Kafka client properties from system environment variables.

With this change environment variables without a cluster name, e.g. `KAFKA_BOOTSTRAP_SERVERS` will be treated as a _common_ property, i.e. applied to all clusters.  Env vars can still have specific cluster names, e.g. `KAFKA_BOB_BOOTSTRAP_SERVERS` will set `bootstrap.servers` on cluster `bob`.

This means in the most common situation of only a single cluster, normally _default_ cluster, properties can be set using the common property names. In the more complex and uncommon situation of multiple clusters, then users can use a powerful combination of both common and specific properties.

### Reviewer checklist
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [x] Ensure any appropriate documentation has been added or amended