### PR TITLE
Implement empty `ResourceHandler`

### DIFF
--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsExtensionProvider.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsExtensionProvider.java
@@ -25,11 +25,11 @@ import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
 import org.creekservice.api.kafka.streams.extension.KafkaStreamsExtensionOptions;
 import org.creekservice.api.service.extension.CreekExtensionProvider;
 import org.creekservice.api.service.extension.CreekService;
-import org.creekservice.api.service.extension.model.ResourceHandler;
 import org.creekservice.internal.kafka.common.resource.KafkaResourceValidator;
 import org.creekservice.internal.kafka.streams.extension.config.ClustersPropertiesFactory;
 import org.creekservice.internal.kafka.streams.extension.resource.ResourceRegistry;
 import org.creekservice.internal.kafka.streams.extension.resource.ResourceRegistryFactory;
+import org.creekservice.internal.kafka.streams.extension.resource.TopicResourceHandler;
 
 /** Provider of {@link org.creekservice.api.kafka.streams.extension.KafkaStreamsExtension}. */
 public final class KafkaStreamsExtensionProvider implements CreekExtensionProvider {
@@ -69,7 +69,7 @@ public final class KafkaStreamsExtensionProvider implements CreekExtensionProvid
 
     @Override
     public StreamsExtension initialize(final CreekService api) {
-        api.model().addResource(KafkaTopicDescriptor.class, new ResourceHandler<>() {});
+        api.model().addResource(KafkaTopicDescriptor.class, new TopicResourceHandler());
 
         final KafkaStreamsExtensionOptions options =
                 api.options()

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/TopicResourceHandler.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/TopicResourceHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.streams.extension.resource;
+
+
+import java.util.Collection;
+import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
+import org.creekservice.api.platform.metadata.ResourceHandler;
+
+@SuppressWarnings("rawtypes")
+public class TopicResourceHandler implements ResourceHandler<KafkaTopicDescriptor> {
+    @Override
+    public void validate(final Collection<KafkaTopicDescriptor> resourceGroup) {
+    }
+
+    @Override
+    public void ensure(final Collection<KafkaTopicDescriptor> resources) {
+    }
+}

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/TopicResourceHandler.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/TopicResourceHandler.java
@@ -24,10 +24,8 @@ import org.creekservice.api.platform.metadata.ResourceHandler;
 @SuppressWarnings("rawtypes")
 public class TopicResourceHandler implements ResourceHandler<KafkaTopicDescriptor> {
     @Override
-    public void validate(final Collection<KafkaTopicDescriptor> resourceGroup) {
-    }
+    public void validate(final Collection<KafkaTopicDescriptor> resourceGroup) {}
 
     @Override
-    public void ensure(final Collection<KafkaTopicDescriptor> resources) {
-    }
+    public void ensure(final Collection<KafkaTopicDescriptor> resources) {}
 }


### PR DESCRIPTION
`ResourceHandler` is now defined in the `creek-platform-metadata` jar.  Update code to reflect this.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended