### PR TITLE
Support initialising extensions with more than one component

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,10 @@ subprojects {
 
     project.version = project.parent?.version!!
 
+    configurations.all {
+        resolutionStrategy.cacheChangingModulesFor(10, TimeUnit.MINUTES)
+    }
+
     extra.apply {
         set("creekBaseVersion", "0.2.0-SNAPSHOT")
         set("creekTestVersion", "0.2.0-SNAPSHOT")

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsExtensionProvider.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsExtensionProvider.java
@@ -18,11 +18,12 @@ package org.creekservice.internal.kafka.streams.extension;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.stream.Stream;
+import java.util.Collection;
 import org.creekservice.api.base.annotation.VisibleForTesting;
 import org.creekservice.api.kafka.common.config.ClustersProperties;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
 import org.creekservice.api.kafka.streams.extension.KafkaStreamsExtensionOptions;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
 import org.creekservice.api.platform.metadata.ResourceHandler;
 import org.creekservice.api.service.extension.CreekExtensionProvider;
 import org.creekservice.api.service.extension.CreekService;
@@ -70,7 +71,8 @@ public final class KafkaStreamsExtensionProvider implements CreekExtensionProvid
 
     @SuppressWarnings({"unchecked", "RedundantCast", "rawtypes"})
     @Override
-    public StreamsExtension initialize(final CreekService api) {
+    public StreamsExtension initialize(
+            final CreekService api, final Collection<? extends ComponentDescriptor> components) {
         api.model()
                 .addResource(
                         KafkaTopicDescriptor.class, (ResourceHandler) new TopicResourceHandler());
@@ -80,9 +82,9 @@ public final class KafkaStreamsExtensionProvider implements CreekExtensionProvid
                         .get(KafkaStreamsExtensionOptions.class)
                         .orElseGet(() -> KafkaStreamsExtensionOptions.builder().build());
 
-        resourceValidator.validate(Stream.of(api.service()));
-        final ClustersProperties properties = propertiesFactory.create(api.service(), options);
-        final ResourceRegistry resources = resourcesFactory.create(api.service(), properties);
+        resourceValidator.validate(components.stream());
+        final ClustersProperties properties = propertiesFactory.create(components, options);
+        final ResourceRegistry resources = resourcesFactory.create(components, properties);
         final KafkaStreamsBuilder builder = builderFactory.create(properties);
         final KafkaStreamsExecutor executor = executorFactory.create(options);
 

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/config/ClustersPropertiesFactory.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/config/ClustersPropertiesFactory.java
@@ -19,7 +19,6 @@ package org.creekservice.internal.kafka.streams.extension.config;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -28,7 +27,6 @@ import org.creekservice.api.kafka.common.config.ClustersProperties;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
 import org.creekservice.api.kafka.streams.extension.KafkaStreamsExtensionOptions;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
-import org.creekservice.api.platform.metadata.ServiceDescriptor;
 
 public final class ClustersPropertiesFactory {
 
@@ -44,11 +42,11 @@ public final class ClustersPropertiesFactory {
     }
 
     public ClustersProperties create(
-            final ServiceDescriptor serviceDescriptor,
+            final Collection<? extends ComponentDescriptor> components,
             final KafkaStreamsExtensionOptions apiOptions) {
 
         final Set<String> clusterNames =
-                topicCollector.collectTopics(List.of(serviceDescriptor)).values().stream()
+                topicCollector.collectTopics(components).values().stream()
                         .map(KafkaTopicDescriptor::cluster)
                         .collect(Collectors.toSet());
 

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistryFactory.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistryFactory.java
@@ -19,7 +19,6 @@ package org.creekservice.internal.kafka.streams.extension.resource;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.serialization.Serde;
@@ -59,10 +58,11 @@ public final class ResourceRegistryFactory {
     }
 
     public ResourceRegistry create(
-            final ComponentDescriptor component, final ClustersProperties properties) {
+            final Collection<? extends ComponentDescriptor> components,
+            final ClustersProperties properties) {
 
         final Map<String, KafkaTopicDescriptor<?, ?>> topicDefs =
-                topicCollector.collectTopics(List.of(component));
+                topicCollector.collectTopics(components);
 
         final Map<String, Topic<?, ?>> topics =
                 topicDefs.entrySet().stream()

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/config/ClustersPropertiesFactoryTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/config/ClustersPropertiesFactoryTest.java
@@ -23,14 +23,14 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import org.creekservice.api.kafka.common.config.ClustersProperties;
 import org.creekservice.api.kafka.common.config.KafkaPropertyOverrides;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
 import org.creekservice.api.kafka.streams.extension.KafkaStreamsExtensionOptions;
-import org.creekservice.api.platform.metadata.ServiceDescriptor;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,7 +41,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ClustersPropertiesFactoryTest {
 
     @Mock private ClustersPropertiesFactory.TopicCollector topicCollector;
-    @Mock private ServiceDescriptor serviceDescriptor;
+    @Mock private Collection<? extends ComponentDescriptor> components;
     @Mock private ClustersProperties.Builder propertiesBuilder;
     @Mock private ClustersProperties.Builder updatedPropertiesBuilder;
     @Mock private KafkaPropertyOverrides propertiesOverrides;
@@ -59,8 +59,7 @@ class ClustersPropertiesFactoryTest {
         when(options.propertiesBuilder()).thenReturn(propertiesBuilder);
         when(options.propertyOverrides()).thenReturn(propertiesOverrides);
 
-        when(topicCollector.collectTopics(List.of(serviceDescriptor)))
-                .thenReturn(Map.of("a", topicA, "b", topicB));
+        when(topicCollector.collectTopics(components)).thenReturn(Map.of("a", topicA, "b", topicB));
 
         when(topicA.cluster()).thenReturn("cluster-A");
         when(topicB.cluster()).thenReturn("cluster-B");
@@ -73,7 +72,7 @@ class ClustersPropertiesFactoryTest {
     @Test
     void shouldPassClusterNamesToOverridesProvider() {
         // When:
-        factory.create(serviceDescriptor, options);
+        factory.create(components, options);
 
         // Then:
         verify(propertiesOverrides).get(Set.of("cluster-A", "cluster-B"));
@@ -85,7 +84,7 @@ class ClustersPropertiesFactoryTest {
         when(topicB.cluster()).thenReturn("cluster-A");
 
         // When:
-        factory.create(serviceDescriptor, options);
+        factory.create(components, options);
 
         // Then:
         verify(propertiesOverrides).get(Set.of("cluster-A"));
@@ -94,7 +93,7 @@ class ClustersPropertiesFactoryTest {
     @Test
     void shouldApplyOverridesToProperties() {
         // When:
-        factory.create(serviceDescriptor, options);
+        factory.create(components, options);
 
         // Then:
         verify(propertiesBuilder).putAll(propertyOverrides);
@@ -103,7 +102,7 @@ class ClustersPropertiesFactoryTest {
     @Test
     void shouldReturnProperties() {
         // When:
-        final ClustersProperties result = factory.create(serviceDescriptor, options);
+        final ClustersProperties result = factory.create(components, options);
 
         // Then:
         assertThat(result, is(buildProperties));

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistryFactoryTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistryFactoryTest.java
@@ -25,7 +25,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 import org.apache.kafka.common.serialization.Serde;
 import org.creekservice.api.kafka.common.config.ClustersProperties;
@@ -52,7 +52,7 @@ class ResourceRegistryFactoryTest {
     private static final Map<String, ?> SOME_CONFIG = Map.of("some", "config");
     private static final String CLUSTER_NAME = "bob";
 
-    @Mock private ComponentDescriptor component;
+    @Mock private Collection<? extends ComponentDescriptor> components;
     @Mock private ResourceRegistryFactory.TopicCollector topicCollector;
     @Mock private ResourceRegistryFactory.RegistryFactory registryFactory;
     @Mock private ResourceRegistryFactory.TopicFactory topicFactory;
@@ -106,10 +106,10 @@ class ResourceRegistryFactoryTest {
     @Test
     void shouldCollectTopicDescriptors() {
         // When:
-        factory.create(component, clusterProperties);
+        factory.create(components, clusterProperties);
 
         // Then:
-        verify(topicCollector).collectTopics(List.of(component));
+        verify(topicCollector).collectTopics(components);
     }
 
     @Test
@@ -118,7 +118,7 @@ class ResourceRegistryFactoryTest {
         when(topicCollector.collectTopics(any())).thenReturn(Map.of());
 
         // When:
-        final ResourceRegistry result = factory.create(component, clusterProperties);
+        final ResourceRegistry result = factory.create(components, clusterProperties);
 
         // Then:
         verify(registryFactory).create(Map.of());
@@ -128,7 +128,7 @@ class ResourceRegistryFactoryTest {
     @Test
     void shouldGetKeySerdeFromProviders() {
         // When:
-        factory.create(component, clusterProperties);
+        factory.create(components, clusterProperties);
 
         // Then:
         verify(serdeProviders).get(topicDefA.key().format());
@@ -139,7 +139,7 @@ class ResourceRegistryFactoryTest {
     @Test
     void shouldGetValueSerdeFromProviders() {
         // When:
-        factory.create(component, clusterProperties);
+        factory.create(components, clusterProperties);
 
         // Then:
         verify(serdeProviders).get(topicDefA.value().format());
@@ -153,7 +153,7 @@ class ResourceRegistryFactoryTest {
         when(topicDefA.value()).thenReturn(customPart);
 
         // When:
-        factory.create(component, clusterProperties);
+        factory.create(components, clusterProperties);
 
         // Then:
         verify(valueSerdeProvider).create(customPart);
@@ -166,7 +166,7 @@ class ResourceRegistryFactoryTest {
         when(clusterProperties.get(CLUSTER_NAME)).thenReturn((Map) SOME_CONFIG);
 
         // When:
-        factory.create(component, clusterProperties);
+        factory.create(components, clusterProperties);
 
         // Then:
         verify(keySerde).configure(SOME_CONFIG, true);
@@ -179,7 +179,7 @@ class ResourceRegistryFactoryTest {
         when(clusterProperties.get(CLUSTER_NAME)).thenReturn((Map) SOME_CONFIG);
 
         // When:
-        factory.create(component, clusterProperties);
+        factory.create(components, clusterProperties);
 
         // Then:
         verify(valueSerde).configure(SOME_CONFIG, false);
@@ -188,7 +188,7 @@ class ResourceRegistryFactoryTest {
     @Test
     void shouldCreateTopicsWithCorrectParams() {
         // When:
-        factory.create(component, clusterProperties);
+        factory.create(components, clusterProperties);
 
         // Then:
         verify(topicFactory).create(eq(topicDefA), any(), any());
@@ -202,7 +202,7 @@ class ResourceRegistryFactoryTest {
         when(topicFactory.create(eq(topicDefB), any(), any())).thenReturn(topicTwo);
 
         // When:
-        factory.create(component, clusterProperties);
+        factory.create(components, clusterProperties);
 
         // Then:
         verify(registryFactory).create(Map.of("A", topicOne, "B", topicTwo));
@@ -217,7 +217,8 @@ class ResourceRegistryFactoryTest {
         // When:
         final Exception e =
                 assertThrows(
-                        RuntimeException.class, () -> factory.create(component, clusterProperties));
+                        RuntimeException.class,
+                        () -> factory.create(components, clusterProperties));
 
         // Then:
         assertThat(
@@ -236,7 +237,8 @@ class ResourceRegistryFactoryTest {
         // When:
         final Exception e =
                 assertThrows(
-                        RuntimeException.class, () -> factory.create(component, clusterProperties));
+                        RuntimeException.class,
+                        () -> factory.create(components, clusterProperties));
 
         // Then:
         assertThat(


### PR DESCRIPTION
Part of https://github.com/creek-service/creek-kafka/issues/56

This allows test extensions to internally initialize their non-test extension counterpart to do the heavy lifting, passing all the components under when initializing the non-test extension.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended