### PR TITLE
Remove validate call from `ResourceHandler`.

### DIFF
--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/TopicResourceHandler.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/TopicResourceHandler.java
@@ -16,31 +16,12 @@
 
 package org.creekservice.internal.kafka.streams.extension.resource;
 
-import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
-import org.creekservice.api.base.annotation.VisibleForTesting;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
 import org.creekservice.api.platform.metadata.ResourceHandler;
-import org.creekservice.internal.kafka.common.resource.KafkaResourceValidator;
 
 public class TopicResourceHandler implements ResourceHandler<KafkaTopicDescriptor<?, ?>> {
-
-    private final KafkaResourceValidator validator;
-
-    public TopicResourceHandler() {
-        this(new KafkaResourceValidator());
-    }
-
-    @VisibleForTesting
-    TopicResourceHandler(final KafkaResourceValidator validator) {
-        this.validator = requireNonNull(validator, "validator");
-    }
-
-    @Override
-    public void validate(final Collection<? extends KafkaTopicDescriptor<?, ?>> resourceGroup) {
-        validator.validateGroup(resourceGroup);
-    }
 
     @Override
     public void ensure(final Collection<? extends KafkaTopicDescriptor<?, ?>> resources) {}

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/resource/TopicResourceHandlerTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/resource/TopicResourceHandlerTest.java
@@ -16,39 +16,9 @@
 
 package org.creekservice.internal.kafka.streams.extension.resource;
 
-import static org.mockito.Mockito.verify;
 
-import java.util.Collection;
-import java.util.List;
-import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
-import org.creekservice.internal.kafka.common.resource.KafkaResourceValidator;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class TopicResourceHandlerTest {
-
-    @Mock private KafkaResourceValidator validator;
-    @Mock private KafkaTopicDescriptor<?, ?> descriptor;
-    private TopicResourceHandler handler;
-
-    @BeforeEach
-    void setUp() {
-        handler = new TopicResourceHandler(validator);
-    }
-
-    @Test
-    void shouldValidateGroup() {
-        // Given:
-        final Collection<? extends KafkaTopicDescriptor<?, ?>> group = List.of(descriptor);
-
-        // When:
-        handler.validate(group);
-
-        // Then:
-        verify(validator).validateGroup(group);
-    }
-}
+class TopicResourceHandlerTest {}


### PR DESCRIPTION
part of: https://github.com/creek-service/creek-kafka/issues/56

Given a service extension will be passed all components under test as part of the api passed to the initialize call, and that the extension will use the components' resource descriptors to initialize itself, and will therefore need to validate descriptors and that this is done _before_ the resource initializer can call validate... there is no point to then calling validate again here.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended