### PR TITLE
Group topics by id

### DIFF
--- a/common/src/main/java/org/creekservice/internal/kafka/common/resource/TopicCollector.java
+++ b/common/src/main/java/org/creekservice/internal/kafka/common/resource/TopicCollector.java
@@ -19,6 +19,7 @@ package org.creekservice.internal.kafka.common.resource;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.groupingBy;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -40,7 +41,7 @@ public final class TopicCollector {
      * @param components the components to extract topics from.
      * @return the map of topics by name.
      */
-    public static Map<String, KafkaTopicDescriptor<?, ?>> collectTopics(
+    public static Map<URI, KafkaTopicDescriptor<?, ?>> collectTopics(
             final Collection<? extends ComponentDescriptor> components) {
         return components.stream()
                 .flatMap(ComponentDescriptor::resources)
@@ -48,7 +49,7 @@ public final class TopicCollector {
                 .map(d -> (KafkaTopicDescriptor<?, ?>) d)
                 .collect(
                         groupingBy(
-                                KafkaTopicDescriptor::name,
+                                KafkaTopicDescriptor::id,
                                 collectingAndThen(
                                         Collectors.toList(),
                                         TopicCollector::throwOnDescriptorMismatch)));

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/config/ClustersPropertiesFactory.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/config/ClustersPropertiesFactory.java
@@ -18,6 +18,7 @@ package org.creekservice.internal.kafka.streams.extension.config;
 
 import static java.util.Objects.requireNonNull;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -56,7 +57,7 @@ public final class ClustersPropertiesFactory {
 
     @VisibleForTesting
     interface TopicCollector {
-        Map<String, KafkaTopicDescriptor<?, ?>> collectTopics(
+        Map<URI, KafkaTopicDescriptor<?, ?>> collectTopics(
                 Collection<? extends ComponentDescriptor> components);
     }
 }

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistry.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistry.java
@@ -36,7 +36,7 @@ public final class ResourceRegistry {
     public <K, V> KafkaTopic<K, V> topic(final KafkaTopicDescriptor<K, V> def) {
         final Topic<?, ?> found = topics.get(def.id());
         if (found == null) {
-            throw new UnknownTopicException(def.name());
+            throw new UnknownTopicException(def.id());
         }
 
         if (!KafkaTopicDescriptors.matches(found.descriptor(), def)) {
@@ -47,8 +47,8 @@ public final class ResourceRegistry {
     }
 
     private static final class UnknownTopicException extends IllegalArgumentException {
-        UnknownTopicException(final String name) {
-            super("Unknown topic. No component has a topic of the supplied name. topic=" + name);
+        UnknownTopicException(final URI id) {
+            super("Unknown topic. No topic has the supplied id. id=" + id);
         }
     }
 

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistry.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistry.java
@@ -18,6 +18,7 @@ package org.creekservice.internal.kafka.streams.extension.resource;
 
 import static java.util.Objects.requireNonNull;
 
+import java.net.URI;
 import java.util.Map;
 import org.creekservice.api.kafka.common.resource.KafkaTopic;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
@@ -25,15 +26,15 @@ import org.creekservice.internal.kafka.common.resource.KafkaTopicDescriptors;
 
 public final class ResourceRegistry {
 
-    private final Map<String, Topic<?, ?>> topics;
+    private final Map<URI, Topic<?, ?>> topics;
 
-    ResourceRegistry(final Map<String, Topic<?, ?>> topics) {
+    ResourceRegistry(final Map<URI, Topic<?, ?>> topics) {
         this.topics = Map.copyOf(requireNonNull(topics, "topics"));
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     public <K, V> KafkaTopic<K, V> topic(final KafkaTopicDescriptor<K, V> def) {
-        final Topic<?, ?> found = topics.get(def.name());
+        final Topic<?, ?> found = topics.get(def.id());
         if (found == null) {
             throw new UnknownTopicException(def.name());
         }

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistryFactory.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistryFactory.java
@@ -18,6 +18,7 @@ package org.creekservice.internal.kafka.streams.extension.resource;
 
 import static java.util.Objects.requireNonNull;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -61,10 +62,10 @@ public final class ResourceRegistryFactory {
             final Collection<? extends ComponentDescriptor> components,
             final ClustersProperties properties) {
 
-        final Map<String, KafkaTopicDescriptor<?, ?>> topicDefs =
+        final Map<URI, KafkaTopicDescriptor<?, ?>> topicDefs =
                 topicCollector.collectTopics(components);
 
-        final Map<String, Topic<?, ?>> topics =
+        final Map<URI, Topic<?, ?>> topics =
                 topicDefs.entrySet().stream()
                         .collect(
                                 Collectors.toUnmodifiableMap(
@@ -108,7 +109,7 @@ public final class ResourceRegistryFactory {
 
     @VisibleForTesting
     interface TopicCollector {
-        Map<String, KafkaTopicDescriptor<?, ?>> collectTopics(
+        Map<URI, KafkaTopicDescriptor<?, ?>> collectTopics(
                 Collection<? extends ComponentDescriptor> components);
     }
 
@@ -120,7 +121,7 @@ public final class ResourceRegistryFactory {
 
     @VisibleForTesting
     interface RegistryFactory {
-        ResourceRegistry create(Map<String, Topic<?, ?>> topics);
+        ResourceRegistry create(Map<URI, Topic<?, ?>> topics);
     }
 
     private static final class UnknownSerializationFormatException extends RuntimeException {

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/config/ClustersPropertiesFactoryTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/config/ClustersPropertiesFactoryTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -59,7 +60,13 @@ class ClustersPropertiesFactoryTest {
         when(options.propertiesBuilder()).thenReturn(propertiesBuilder);
         when(options.propertyOverrides()).thenReturn(propertiesOverrides);
 
-        when(topicCollector.collectTopics(components)).thenReturn(Map.of("a", topicA, "b", topicB));
+        when(topicCollector.collectTopics(components))
+                .thenReturn(
+                        Map.of(
+                                URI.create("topic://default/a"),
+                                topicA,
+                                URI.create("topic://default/b"),
+                                topicB));
 
         when(topicA.cluster()).thenReturn("cluster-A");
         when(topicB.cluster()).thenReturn("cluster-B");

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistryFactoryTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistryFactoryTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
 import org.apache.kafka.common.serialization.Serde;
@@ -100,7 +101,8 @@ class ResourceRegistryFactoryTest {
 
         when(topicFactory.create(any(), any(), any())).thenReturn((Topic) topicOne);
 
-        when(topicCollector.collectTopics(any())).thenReturn(Map.of("A", topicDefA));
+        when(topicCollector.collectTopics(any()))
+                .thenReturn(Map.of(URI.create("topic://default/A"), topicDefA));
     }
 
     @Test
@@ -198,14 +200,25 @@ class ResourceRegistryFactoryTest {
     void shouldCreateTopicResourcesForEachTopicDescriptor() {
         // Given:
         when(topicCollector.collectTopics(any()))
-                .thenReturn(Map.of("A", topicDefA, "B", topicDefB));
+                .thenReturn(
+                        Map.of(
+                                URI.create("topic://default/a"),
+                                topicDefA,
+                                URI.create("topic://default/b"),
+                                topicDefB));
         when(topicFactory.create(eq(topicDefB), any(), any())).thenReturn(topicTwo);
 
         // When:
         factory.create(components, clusterProperties);
 
         // Then:
-        verify(registryFactory).create(Map.of("A", topicOne, "B", topicTwo));
+        verify(registryFactory)
+                .create(
+                        Map.of(
+                                URI.create("topic://default/a"),
+                                topicOne,
+                                URI.create("topic://default/b"),
+                                topicTwo));
     }
 
     @Test

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistryTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/resource/ResourceRegistryTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.net.URI;
 import java.util.Map;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.PartDescriptor;
@@ -50,7 +51,13 @@ class ResourceRegistryTest {
 
     @BeforeEach
     void setUp() {
-        registry = new ResourceRegistry(Map.of("topic-A", topicA, "topic-B", topicB));
+        registry =
+                new ResourceRegistry(
+                        Map.of(
+                                URI.create("topic://default/topic-A"),
+                                topicA,
+                                URI.create("topic://default/topic-B"),
+                                topicB));
 
         when(topicA.descriptor()).thenReturn(topicDefA);
         when(topicB.descriptor()).thenReturn(topicDefB);


### PR DESCRIPTION
Code previously grouped topic descriptors by topic name.  This would cause invalid results if there were descriptors for two topics with the same name, but on different clusters.

Grouping by resource id ensures the correct grouping.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended