### PR TITLE
Switch to shared binary clients

### DIFF
--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/KafkaClientsExtension.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/KafkaClientsExtension.java
@@ -17,13 +17,18 @@
 package org.creekservice.api.kafka.extension;
 
 
+import java.io.Closeable;
+import java.io.IOException;
+import java.time.Duration;
 import java.util.Properties;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
 import org.creekservice.api.kafka.extension.resource.KafkaTopic;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
 import org.creekservice.api.service.extension.CreekExtension;
 
 /** Kafka client extension to Creek. */
-public interface KafkaClientsExtension extends CreekExtension {
+public interface KafkaClientsExtension extends CreekExtension, Closeable {
 
     /**
      * Get the Kafka properties that should be used to build a topology.
@@ -44,4 +49,74 @@ public interface KafkaClientsExtension extends CreekExtension {
      * @return the topic resource.
      */
     <K, V> KafkaTopic<K, V> topic(KafkaTopicDescriptor<K, V> def);
+
+    /**
+     * Get the shared producer for a cluster.
+     *
+     * <p>Using a shared binary producer is more efficient that creating different producers, with
+     * different serializers, for different topics.
+     *
+     * <p>The {@link KafkaTopic#serializeKey} and {@link KafkaTopic#serializeValue} convenience
+     * methods can be used to serialize the key and value for use with this binary producer.
+     *
+     * @param clusterName the name of the cluster.
+     * @return the shared producer.
+     */
+    Producer<byte[], byte[]> producer(String clusterName);
+
+    /**
+     * Convenience method for getting the shared producer for the default cluster.
+     *
+     * @see #producer(String)
+     */
+    default Producer<byte[], byte[]> producer() {
+        return producer(KafkaTopicDescriptor.DEFAULT_CLUSTER_NAME);
+    }
+
+    /**
+     * Get the shared consumer for a cluster.
+     *
+     * <p>Using a shared binary consumer is more efficient that creating different consumers, with
+     * different deserializers, for different topics.
+     *
+     * <p>The {@link KafkaTopic#deserializeKey} and {@link KafkaTopic#deserializeValue} convenience
+     * methods can be used to deserialize the keys and values returned by this binary consumer.
+     *
+     * @param clusterName the name of the cluster.
+     * @return the shared consumer.
+     */
+    Consumer<byte[], byte[]> consumer(String clusterName);
+
+    /**
+     * Convenience method for getting the shared consumer for the default cluster.
+     *
+     * @see #consumer(String)
+     */
+    default Consumer<byte[], byte[]> consumer() {
+        return consumer(KafkaTopicDescriptor.DEFAULT_CLUSTER_NAME);
+    }
+
+    /**
+     * Close the resources associated with the extension.
+     *
+     * <p>Closes all shared {@link #producer(String) producers} and {@link #consumer(String)}
+     * consumers}, waiting for up to the supplier {@code timeout} for <i>each<i> to close.
+     *
+     * <p>See {@link org.apache.kafka.clients.producer.KafkaProducer#close(Duration)} See {@link
+     * org.apache.kafka.clients.consumer.KafkaConsumer#close(Duration)}
+     */
+    void close(Duration timeout) throws IOException;
+
+    /**
+     * Close the resources associated with the extension.
+     *
+     * <p>Closes all shared {@link #producer(String) producers} and {@link #consumer(String)}
+     * consumers}, waiting until all previously sent requests complete.
+     *
+     * <p>See {@link org.apache.kafka.clients.producer.KafkaProducer#close(Duration)} See {@link
+     * org.apache.kafka.clients.consumer.KafkaConsumer#close(Duration)}
+     */
+    default void close() throws IOException {
+        close(Duration.ofMillis(Long.MAX_VALUE));
+    }
 }

--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/resource/KafkaTopic.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/resource/KafkaTopic.java
@@ -17,9 +17,8 @@
 package org.creekservice.api.kafka.extension.resource;
 
 
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.serialization.Serde;
+import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
 
 /**
  * A Kafka topic resource.
@@ -32,15 +31,52 @@ public interface KafkaTopic<K, V> {
     /** @return the name of the topic */
     String name();
 
+    /** @return the value type */
+    KafkaTopicDescriptor<K, V> descriptor();
+
     /** @return the serde used to (de)serialize the keys stored in the topic */
     Serde<K> keySerde();
 
     /** @return the serde used to (de)serialize the values stored in the topic */
     Serde<V> valueSerde();
 
-    /** @return a Kafka producer configured to produce to this topic */
-    Producer<K, V> producer();
+    /**
+     * Convenience method for serializing a key instance.
+     *
+     * @param key the key to serialize.
+     * @return the binary serialized key.
+     */
+    default byte[] serializeKey(final K key) {
+        return keySerde().serializer().serialize(name(), key);
+    }
 
-    /** @return a Kafka consumer configured to consume from this topic */
-    Consumer<K, V> consumer();
+    /**
+     * Convenience method for serializing a value instance.
+     *
+     * @param value the value to serialize.
+     * @return the binary serialized value.
+     */
+    default byte[] serializeValue(final V value) {
+        return valueSerde().serializer().serialize(name(), value);
+    }
+
+    /**
+     * Convenience method for deserializing a key instance.
+     *
+     * @param key the binary key to deserialize.
+     * @return the deserialized key.
+     */
+    default K deserializeKey(final byte[] key) {
+        return keySerde().deserializer().deserialize(name(), key);
+    }
+
+    /**
+     * Convenience method for deserializing a value instance.
+     *
+     * @param value the binary value to deserialize.
+     * @return the deserialized value.
+     */
+    default V deserializeValue(final byte[] value) {
+        return valueSerde().deserializer().deserialize(name(), value);
+    }
 }

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistry.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistry.java
@@ -33,16 +33,25 @@ public final class ResourceRegistry {
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     public <K, V> KafkaTopic<K, V> topic(final KafkaTopicDescriptor<K, V> def) {
-        final Topic<?, ?> found = topics.get(def.id());
-        if (found == null) {
-            throw new UnknownTopicException(def.id());
-        }
+        final Topic<?, ?> found = find(def.id());
 
         if (!KafkaTopicDescriptors.matches(found.descriptor(), def)) {
             throw new TopicDescriptorMismatchException(def, found.descriptor());
         }
 
         return (KafkaTopic) found;
+    }
+
+    public KafkaTopic<?, ?> topic(final String cluster, final String topic) {
+        return find(KafkaTopicDescriptor.resourceId(cluster, topic));
+    }
+
+    private Topic<?, ?> find(final URI id) {
+        final Topic<?, ?> found = topics.get(id);
+        if (found == null) {
+            throw new UnknownTopicException(id);
+        }
+        return found;
     }
 
     private static final class UnknownTopicException extends IllegalArgumentException {

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistryFactory.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistryFactory.java
@@ -76,7 +76,7 @@ public final class ResourceRegistryFactory {
         final Map<String, Object> properties = allProperties.get(def.cluster());
         final Serde<K> keySerde = serde(def.key(), def.name(), true, properties);
         final Serde<V> valueSerde = serde(def.value(), def.name(), false, properties);
-        return topicFactory.create(def, keySerde, valueSerde, properties);
+        return topicFactory.create(def, keySerde, valueSerde);
     }
 
     private <T> Serde<T> serde(
@@ -105,10 +105,7 @@ public final class ResourceRegistryFactory {
     @VisibleForTesting
     interface TopicFactory {
         <K, V> Topic<K, V> create(
-                KafkaTopicDescriptor<K, V> def,
-                Serde<K> keySerde,
-                Serde<V> valueSerde,
-                Map<String, Object> clientProperties);
+                KafkaTopicDescriptor<K, V> def, Serde<K> keySerde, Serde<V> valueSerde);
     }
 
     @VisibleForTesting

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/Topic.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/Topic.java
@@ -18,11 +18,6 @@ package org.creekservice.internal.kafka.extension.resource;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Map;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.serialization.Serde;
 import org.creekservice.api.kafka.extension.resource.KafkaTopic;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
@@ -32,22 +27,24 @@ public final class Topic<K, V> implements KafkaTopic<K, V> {
     private final KafkaTopicDescriptor<K, V> descriptor;
     private final Serde<K> keySerde;
     private final Serde<V> valueSerde;
-    private final Map<String, Object> clientProperties;
 
     public Topic(
             final KafkaTopicDescriptor<K, V> descriptor,
             final Serde<K> keySerde,
-            final Serde<V> valueSerde,
-            final Map<String, Object> clientProperties) {
+            final Serde<V> valueSerde) {
         this.descriptor = requireNonNull(descriptor, "descriptor");
         this.keySerde = requireNonNull(keySerde, "keySerde");
         this.valueSerde = requireNonNull(valueSerde, "valueSerde");
-        this.clientProperties = Map.copyOf(requireNonNull(clientProperties, "clientProperties"));
     }
 
     @Override
     public String name() {
         return descriptor.name();
+    }
+
+    @Override
+    public KafkaTopicDescriptor<K, V> descriptor() {
+        return descriptor;
     }
 
     @Override
@@ -58,21 +55,5 @@ public final class Topic<K, V> implements KafkaTopic<K, V> {
     @Override
     public Serde<V> valueSerde() {
         return valueSerde;
-    }
-
-    @Override
-    public Producer<K, V> producer() {
-        return new KafkaProducer<>(
-                clientProperties, keySerde.serializer(), valueSerde.serializer());
-    }
-
-    @Override
-    public Consumer<K, V> consumer() {
-        return new KafkaConsumer<>(
-                clientProperties, keySerde.deserializer(), valueSerde.deserializer());
-    }
-
-    public KafkaTopicDescriptor<K, V> descriptor() {
-        return descriptor;
     }
 }

--- a/client-extension/src/test/java/module-info.test
+++ b/client-extension/src/test/java/module-info.test
@@ -20,7 +20,7 @@
   org.junit.platform.commons/org.junit.platform.commons.util=junit.jupiter
 
 --add-opens
-  creek.kafka.clients.extension/org.creekservice.internal.kafka.extension.client=junit.jupiter
+  creek.kafka.clients.extension/org.creekservice.internal.kafka.extension=junit.jupiter
 
 --add-opens
-  creek.kafka.clients.extension/org.creekservice.internal.kafka.extension.resource=junit.jupiter
+  creek.kafka.clients.extension/org.creekservice.internal.kafka.extension.client=junit.jupiter

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistryFactoryTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistryFactoryTest.java
@@ -25,7 +25,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
@@ -100,7 +99,7 @@ class ResourceRegistryFactoryTest {
         setUpTopic(topicDefA, "a", aKeyPart, aValuePart);
         setUpTopic(topicDefB, "b", bKeyPart, bValuePart);
 
-        when(topicFactory.create(any(), any(), any(), any())).thenReturn((Topic) topicOne);
+        when(topicFactory.create(any(), any(), any())).thenReturn((Topic) topicOne);
 
         when(topicCollector.collectTopics(any()))
                 .thenReturn(Map.of(URI.create("topic://default/A"), topicDefA));
@@ -136,7 +135,7 @@ class ResourceRegistryFactoryTest {
         // Then:
         verify(serdeProviders).get(topicDefA.key().format());
         verify(keySerdeProvider).create(topicDefA.key());
-        verify(topicFactory).create(any(), eq(keySerde), any(), any());
+        verify(topicFactory).create(any(), eq(keySerde), any());
     }
 
     @Test
@@ -147,21 +146,7 @@ class ResourceRegistryFactoryTest {
         // Then:
         verify(serdeProviders).get(topicDefA.value().format());
         verify(valueSerdeProvider).create(topicDefA.value());
-        verify(topicFactory).create(any(), any(), eq(valueSerde), any());
-    }
-
-    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
-    @Test
-    void shouldGetClientPropsFromClustersProps() {
-        // Given:
-        when(clusterProperties.get(CLUSTER_NAME)).thenReturn(SOME_CONFIG);
-
-        // When:
-        factory.create(components, clusterProperties);
-
-        // Then:
-        verify(clusterProperties).get(topicDefA.cluster());
-        verify(topicFactory).create(any(), any(), any(), eq(SOME_CONFIG));
+        verify(topicFactory).create(any(), any(), eq(valueSerde));
     }
 
     @Test
@@ -206,7 +191,7 @@ class ResourceRegistryFactoryTest {
         factory.create(components, clusterProperties);
 
         // Then:
-        verify(topicFactory).create(eq(topicDefA), any(), any(), any());
+        verify(topicFactory).create(eq(topicDefA), any(), any());
     }
 
     @Test
@@ -219,7 +204,7 @@ class ResourceRegistryFactoryTest {
                                 topicDefA,
                                 URI.create("topic://default/b"),
                                 topicDefB));
-        when(topicFactory.create(eq(topicDefB), any(), any(), any())).thenReturn(topicTwo);
+        when(topicFactory.create(eq(topicDefB), any(), any())).thenReturn(topicTwo);
 
         // When:
         factory.create(components, clusterProperties);

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistryTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistryTest.java
@@ -66,9 +66,15 @@ class ResourceRegistryTest {
     }
 
     @Test
-    void shouldGetTopic() {
+    void shouldGetTopicByDef() {
         assertThat(registry.topic(topicDefA), is(topicA));
         assertThat(registry.topic(topicDefB), is(topicB));
+    }
+
+    @Test
+    void shouldGetTopicByName() {
+        assertThat(registry.topic(topicDefA.cluster(), topicDefA.name()), is(topicA));
+        assertThat(registry.topic(topicDefB.cluster(), topicDefB.name()), is(topicB));
     }
 
     @Test

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/TopicTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/TopicTest.java
@@ -16,22 +16,11 @@
 
 package org.creekservice.internal.kafka.extension.resource;
 
-import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
-import java.util.Map;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.common.serialization.LongDeserializer;
-import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.serialization.StringSerializer;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,13 +34,11 @@ class TopicTest {
     @Mock private KafkaTopicDescriptor<Long, String> descriptor;
     @Mock private Serde<Long> keySerde;
     @Mock private Serde<String> valueSerde;
-    private final Map<String, Object> clientProperties =
-            Map.of(BOOTSTRAP_SERVERS_CONFIG, "localhost:8080");
     private Topic<Long, String> topic;
 
     @BeforeEach
     void setUp() {
-        topic = new Topic<>(descriptor, keySerde, valueSerde, clientProperties);
+        topic = new Topic<>(descriptor, keySerde, valueSerde);
     }
 
     @Test
@@ -76,31 +63,5 @@ class TopicTest {
     @Test
     void shouldReturnDescriptor() {
         assertThat(topic.descriptor(), is(descriptor));
-    }
-
-    @Test
-    void shouldReturnConfiguredKafkaProducer() {
-        // Given:
-        when(keySerde.serializer()).thenReturn(new LongSerializer());
-        when(valueSerde.serializer()).thenReturn(new StringSerializer());
-
-        // When:
-        final Producer<Long, String> producer = topic.producer();
-
-        // Then:
-        assertThat(producer, is(instanceOf(KafkaProducer.class)));
-    }
-
-    @Test
-    void shouldReturnConfiguredKafkaConsumer() {
-        // Given:
-        when(keySerde.deserializer()).thenReturn(new LongDeserializer());
-        when(valueSerde.deserializer()).thenReturn(new StringDeserializer());
-
-        // When:
-        final Consumer<Long, String> consumer = topic.consumer();
-
-        // Then:
-        assertThat(consumer, is(instanceOf(KafkaConsumer.class)));
     }
 }

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsExtension.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsExtension.java
@@ -18,7 +18,11 @@ package org.creekservice.internal.kafka.streams.extension;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.IOException;
+import java.time.Duration;
 import java.util.Properties;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 import org.creekservice.api.kafka.extension.KafkaClientsExtension;
@@ -57,6 +61,21 @@ public final class StreamsExtension implements KafkaStreamsExtension {
     @Override
     public <K, V> KafkaTopic<K, V> topic(final KafkaTopicDescriptor<K, V> def) {
         return clientsExtension.topic(def);
+    }
+
+    @Override
+    public Producer<byte[], byte[]> producer(final String clusterName) {
+        return clientsExtension.producer(clusterName);
+    }
+
+    @Override
+    public Consumer<byte[], byte[]> consumer(final String clusterName) {
+        return clientsExtension.consumer(clusterName);
+    }
+
+    @Override
+    public void close(final Duration timeout) throws IOException {
+        clientsExtension.close();
     }
 
     @Override

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsExtension.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsExtension.java
@@ -75,7 +75,7 @@ public final class StreamsExtension implements KafkaStreamsExtension {
 
     @Override
     public void close(final Duration timeout) throws IOException {
-        clientsExtension.close();
+        clientsExtension.close(timeout);
     }
 
     @Override

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsExtensionTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsExtensionTest.java
@@ -20,11 +20,15 @@ import static org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.DEFAULT_C
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.time.Duration;
 import java.util.Properties;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 import org.creekservice.api.kafka.extension.KafkaClientsExtension;
@@ -77,7 +81,7 @@ class StreamsExtensionTest {
     }
 
     @Test
-    void shouldGetTopicsFromRegistry() {
+    void shouldGetTopicsFromClientExt() {
         // Given:
         when(clientExtension.topic(topicDef)).thenReturn(topic);
 
@@ -86,6 +90,46 @@ class StreamsExtensionTest {
 
         // Then:
         assertThat(result, is(topic));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldGetProducerFromClientExt() {
+        // Given:
+        final Producer<byte[], byte[]> producer = mock(Producer.class);
+        when(clientExtension.producer("name")).thenReturn(producer);
+
+        // When:
+        final Producer<byte[], byte[]> result = extension.producer("name");
+
+        // Then:
+        assertThat(result, is(producer));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldGetConsumerFromClientExt() {
+        // Given:
+        final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
+        when(clientExtension.consumer("name")).thenReturn(consumer);
+
+        // When:
+        final Consumer<byte[], byte[]> result = extension.consumer("name");
+
+        // Then:
+        assertThat(result, is(consumer));
+    }
+
+    @Test
+    void shouldCloseClientExtOnClose() throws Exception {
+        // Given:
+        final Duration duration = Duration.ofMillis(1535);
+
+        // When:
+        extension.close(duration);
+
+        // Then:
+        verify(extension).close(duration);
     }
 
     @Test

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsExtensionTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsExtensionTest.java
@@ -129,7 +129,7 @@ class StreamsExtensionTest {
         extension.close(duration);
 
         // Then:
-        verify(extension).close(duration);
+        verify(clientExtension).close(duration);
     }
 
     @Test


### PR DESCRIPTION
Having per-topic consumers and producers would encourage bad usage patterns, i.e. separate consumers and producers for each topic, where a much cleaner and more efficient approach is a single consumer and producer per app.

For now, just expose shared binary producer and consumers and provide helpers for serde of key and value. It's not particularly pretty, but it'll work and maintains the use of the default Kafka clients.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended