### PR TITLE
Basic coercer

### DIFF
--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/yaml/TypeCoercer.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/yaml/TypeCoercer.java
@@ -170,4 +170,3 @@ public final class TypeCoercer {
         }
     }
 }
-

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/yaml/TypeCoercer.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/yaml/TypeCoercer.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.streams.test.extension.yaml;
+
+import static java.util.Objects.requireNonNull;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import org.creekservice.api.base.type.Primitives;
+
+/**
+ * Coerce the values deserialized from test files to the types expected by topics.
+ *
+ * <p>Types deserialized from test files may not bo of the correct type, e.g. while a topic may have
+ * a {@code long} key, small numbers used in test files will be deserialized as {@code Integer}.
+ */
+public final class TypeCoercer {
+
+    private static final Map<Class<?>, Coercer<?>> COERCERS =
+            Map.of(
+                    Integer.class,
+                    Coercer.coercerFor(Integer.class)
+                            .withRule(
+                                    BigDecimal.class,
+                                    value ->
+                                            tryCoerceDecimal(
+                                                    Integer.class,
+                                                    value,
+                                                    new BigDecimal(Integer.MIN_VALUE),
+                                                    new BigDecimal(Integer.MAX_VALUE),
+                                                    BigDecimal::intValue)),
+                    Long.class,
+                    Coercer.coercerFor(Long.class)
+                            .withRule(Integer.class, Integer::longValue)
+                            .withRule(
+                                    BigDecimal.class,
+                                    value ->
+                                            tryCoerceDecimal(
+                                                    Long.class,
+                                                    value,
+                                                    new BigDecimal(Long.MIN_VALUE),
+                                                    new BigDecimal(Long.MAX_VALUE),
+                                                    BigDecimal::longValue)),
+                    BigDecimal.class,
+                    Coercer.coercerFor(BigDecimal.class)
+                            .withRule(Integer.class, BigDecimal::new)
+                            .withRule(Long.class, BigDecimal::new),
+                    UUID.class,
+                    Coercer.coercerFor(UUID.class)
+                            .withRule(String.class, TypeCoercer::uuidFromString));
+
+    /**
+     * Coerce the supplied {@code value} to the supplied {@code targetType}.
+     *
+     * @param value the object to coerce.
+     * @param targetType the type to coerce to.
+     * @param <T> the type to coerce to.
+     * @return the coerced value.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T coerce(final Object value, final Class<T> targetType) {
+        if (value == null) {
+            return null;
+        }
+
+        if (targetType.isAssignableFrom(value.getClass())) {
+            return (T) value;
+        }
+
+        return coercer(targetType).coerce(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Coercer<T> coercer(final Class<T> target) {
+        final Coercer<?> coercer = COERCERS.get(Primitives.box(target));
+        if (coercer != null) {
+            return (Coercer<T>) coercer;
+        }
+
+        return Coercer.coercerFor(target);
+    }
+
+    private static <T> T tryCoerceDecimal(
+            final Class<T> target,
+            final BigDecimal decimal,
+            final BigDecimal min,
+            final BigDecimal max,
+            final Function<BigDecimal, T> mapper) {
+        if (decimal.stripTrailingZeros().scale() > 0) {
+            throw new CoercionFailureException(
+                    "Number with fractional part can not be converted to " + target.getName());
+        }
+
+        if (decimal.compareTo(min) < 0) {
+            throw new CoercionFailureException(
+                    "Number is below the range of values that can be held by a "
+                            + target.getName());
+        }
+
+        if (decimal.compareTo(max) > 0) {
+            throw new CoercionFailureException(
+                    "Number is above the range of values that can be held by a "
+                            + target.getName());
+        }
+
+        return mapper.apply(decimal);
+    }
+
+    private static UUID uuidFromString(final String s) {
+        try {
+            return UUID.fromString(s);
+        } catch (final Exception e) {
+            throw new CoercionFailureException("String can not be converted to UUID: " + s);
+        }
+    }
+
+    private static final class Coercer<T> {
+
+        private final Class<T> targetType;
+        private final Map<Class<?>, Function<?, T>> coercers;
+
+        private Coercer(final Class<T> targetType, final Map<Class<?>, Function<?, T>> coercers) {
+            this.targetType = requireNonNull(targetType, "targetType");
+            this.coercers = Map.copyOf(coercers);
+        }
+
+        static <T> Coercer<T> coercerFor(final Class<T> targetType) {
+            return new Coercer<>(targetType, Map.of());
+        }
+
+        <S> Coercer<T> withRule(final Class<S> instanceType, final Function<S, T> mapper) {
+            final Map<Class<?>, Function<?, T>> coercers = new HashMap<>(this.coercers);
+            coercers.put(instanceType, mapper);
+            return new Coercer<>(targetType, coercers);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <S> T coerce(final S value) {
+            final Function<S, T> mapper =
+                    (Function<S, T>) coercers.getOrDefault(value.getClass(), this::unsupportedType);
+            return mapper.apply(value);
+        }
+
+        private T unsupportedType(final Object value) {
+            throw new CoercionFailureException(
+                    "Can not coerce " + value.getClass().getName() + " to " + targetType.getName());
+        }
+    }
+
+    public static final class CoercionFailureException extends RuntimeException {
+        CoercionFailureException(final String msg) {
+            super(msg);
+        }
+    }
+}
+

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/yaml/TypeCoercerTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/yaml/TypeCoercerTest.java
@@ -18,7 +18,7 @@ package org.creekservice.internal.kafka.streams.test.extension.yaml;
 
 import static java.math.BigDecimal.ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
 

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/yaml/TypeCoercerTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/yaml/TypeCoercerTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.streams.test.extension.yaml;
+
+import static java.math.BigDecimal.ONE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.creekservice.internal.kafka.streams.test.extension.yaml.TypeCoercer.CoercionFailureException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TypeCoercerTest {
+
+    private TypeCoercer coercer;
+
+    @BeforeEach
+    void setUp() {
+        coercer = new TypeCoercer();
+    }
+
+    @Test
+    void shouldCoerceNulls() {
+        assertThat(coercer.coerce(null, Long.class), is(nullValue()));
+        assertThat(coercer.coerce(null, String.class), is(nullValue()));
+    }
+
+    @Test
+    void shouldHandleValuesOfCorrectType() {
+        assertThat(coercer.coerce(10L, Long.class), is(10L));
+        assertThat(coercer.coerce("text", String.class), is("text"));
+    }
+
+    @Test
+    void shouldHandleSubTypes() {
+        assertThat(coercer.coerce(10L, Number.class), is(10L));
+    }
+
+    @Test
+    void shouldThrowOnNonCoercibleType() {
+        // When:
+        final Exception e =
+                assertThrows(
+                        CoercionFailureException.class,
+                        () -> coercer.coerce("text", AtomicBoolean.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is("Can not coerce java.lang.String to java.util.concurrent.atomic.AtomicBoolean"));
+    }
+
+    @Test
+    void shouldThrowIfOnCoercionRule() {
+        // When:
+        final Exception e =
+                assertThrows(
+                        CoercionFailureException.class, () -> coercer.coerce("text", long.class));
+
+        // Then:
+        assertThat(e.getMessage(), is("Can not coerce java.lang.String to java.lang.Long"));
+    }
+
+    @Test
+    void shouldCoerceDecimalToInt() {
+        assertThat(
+                coercer.coerce(new BigDecimal(Integer.MIN_VALUE), int.class),
+                is(Integer.MIN_VALUE));
+        assertThat(
+                coercer.coerce(new BigDecimal(Integer.MAX_VALUE), Integer.class),
+                is(Integer.MAX_VALUE));
+    }
+
+    @Test
+    void shouldFailToConvertDecimalToIntIfFractional() {
+        // When:
+        final Exception e =
+                assertThrows(
+                        CoercionFailureException.class,
+                        () -> coercer.coerce(new BigDecimal("1.01"), int.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is("Number with fractional part can not be converted to java.lang.Integer"));
+    }
+
+    @Test
+    void shouldFailToConvertDecimalToIntIfBelowValidRange() {
+        // When:
+        final Exception e =
+                assertThrows(
+                        CoercionFailureException.class,
+                        () ->
+                                coercer.coerce(
+                                        new BigDecimal(Integer.MIN_VALUE).subtract(ONE),
+                                        int.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is("Number is below the range of values that can be held by a java.lang.Integer"));
+    }
+
+    @Test
+    void shouldFailToConvertDecimalToIntIfAboveValidRange() {
+        // When:
+        final Exception e =
+                assertThrows(
+                        CoercionFailureException.class,
+                        () ->
+                                coercer.coerce(
+                                        new BigDecimal(Integer.MAX_VALUE).add(ONE), int.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is("Number is above the range of values that can be held by a java.lang.Integer"));
+    }
+
+    @Test
+    void shouldCoerceIntToLong() {
+        assertThat(coercer.coerce(10, long.class), is(10L));
+        assertThat(coercer.coerce(-1937575, Long.class), is(-1937575L));
+    }
+
+    @Test
+    void shouldCoerceDecimalToLong() {
+        assertThat(coercer.coerce(new BigDecimal(Long.MIN_VALUE), long.class), is(Long.MIN_VALUE));
+        assertThat(coercer.coerce(new BigDecimal(Long.MAX_VALUE), Long.class), is(Long.MAX_VALUE));
+    }
+
+    @Test
+    void shouldFailToConvertDecimalToLongIfFractional() {
+        // When:
+        final Exception e =
+                assertThrows(
+                        CoercionFailureException.class,
+                        () -> coercer.coerce(new BigDecimal("1.01"), long.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is("Number with fractional part can not be converted to java.lang.Long"));
+    }
+
+    @Test
+    void shouldFailToConvertDecimalToLongIfBelowValidRange() {
+        // When:
+        final Exception e =
+                assertThrows(
+                        CoercionFailureException.class,
+                        () ->
+                                coercer.coerce(
+                                        new BigDecimal(Long.MIN_VALUE).subtract(ONE), long.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is("Number is below the range of values that can be held by a java.lang.Long"));
+    }
+
+    @Test
+    void shouldFailToConvertDecimalToLongIfAboveValidRange() {
+        // When:
+        final Exception e =
+                assertThrows(
+                        CoercionFailureException.class,
+                        () -> coercer.coerce(new BigDecimal(Long.MAX_VALUE).add(ONE), long.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is("Number is above the range of values that can be held by a java.lang.Long"));
+    }
+
+    @Test
+    void shouldCoerceIntToDecimal() {
+        assertThat(coercer.coerce(10, BigDecimal.class), is(new BigDecimal("10")));
+    }
+
+    @Test
+    void shouldCoerceLongToDecimal() {
+        assertThat(coercer.coerce(10L, BigDecimal.class), is(new BigDecimal("10")));
+    }
+
+    @Test
+    void shouldCoerceStringToUUID() {
+        // Given:
+        final UUID uuid = UUID.randomUUID();
+
+        // Then:
+        assertThat(coercer.coerce(uuid.toString(), UUID.class), is(uuid));
+    }
+
+    @Test
+    void shouldThrowIfStringCanNotBeConvertedToUUID() {
+        // When:
+        final Exception e =
+                assertThrows(
+                        CoercionFailureException.class,
+                        () -> coercer.coerce("not a uuid", UUID.class));
+
+        // Then:
+        assertThat(e.getMessage(), is("String can not be converted to UUID: not a uuid"));
+    }
+}


### PR DESCRIPTION
part of https://github.com/creek-service/creek-kafka/issues/125

Topic records read from the YAML test files may not have the correct key and value types, e.g. the topic may be have `long` key, but a small number will be deserialized as an int.

Before producing the record to Kafka the types will need to be coerced to match the topic.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended