### PR TITLE
Remove unused locations

### DIFF
--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicExpectation.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicExpectation.java
@@ -27,9 +27,8 @@ import org.creekservice.api.system.test.extension.test.model.Expectation;
 import org.creekservice.api.system.test.extension.test.model.LocationAware;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-public final class TopicExpectation implements Expectation, LocationAware<TopicExpectation> {
+public final class TopicExpectation implements Expectation {
 
-    private final URI location;
     private final List<TopicRecord> records;
 
     @SuppressWarnings("unused") // Invoked by Jackson via reflection
@@ -38,17 +37,11 @@ public final class TopicExpectation implements Expectation, LocationAware<TopicE
             @JsonProperty(value = "cluster") final Optional<String> clusterName,
             @JsonProperty(value = "notes") final Optional<String> ignored,
             @JsonProperty(value = "records") final List<TopicRecord.RecordBuilder> records) {
-        this(
-                buildRecords(
-                        requireNonNull(clusterName, "clusterName"),
-                        requireNonNull(topicName, "topicName"),
-                        requireNonNull(records, "records")),
-                LocationAware.UNKNOWN_LOCATION);
-    }
+        this.records = List.copyOf(buildRecords(
+                requireNonNull(clusterName, "clusterName"),
+                requireNonNull(topicName, "topicName"),
+                requireNonNull(records, "records")));
 
-    public TopicExpectation(final List<TopicRecord> records, final URI location) {
-        this.location = requireNonNull(location, "location");
-        this.records = List.copyOf(requireNonNull(records, "records"));
         if (records.isEmpty()) {
             throw new IllegalArgumentException("At least one record is required");
         }
@@ -56,15 +49,5 @@ public final class TopicExpectation implements Expectation, LocationAware<TopicE
 
     public List<TopicRecord> records() {
         return List.copyOf(records);
-    }
-
-    @Override
-    public URI location() {
-        return location;
-    }
-
-    @Override
-    public TopicExpectation withLocation(final URI location) {
-        return new TopicExpectation(records, location);
     }
 }

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicInput.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicInput.java
@@ -20,16 +20,14 @@ import static java.util.Objects.requireNonNull;
 import static org.creekservice.internal.kafka.streams.test.extension.model.TopicRecord.RecordBuilder.buildRecords;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.net.URI;
+
 import java.util.List;
 import java.util.Optional;
 import org.creekservice.api.system.test.extension.test.model.Input;
-import org.creekservice.api.system.test.extension.test.model.LocationAware;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-public final class TopicInput implements Input, LocationAware<TopicInput> {
+public final class TopicInput implements Input {
 
-    private final URI location;
     private final List<TopicRecord> records;
 
     @SuppressWarnings("unused") // Invoked by Jackson via reflection
@@ -38,17 +36,11 @@ public final class TopicInput implements Input, LocationAware<TopicInput> {
             @JsonProperty(value = "cluster") final Optional<String> clusterName,
             @JsonProperty(value = "notes") final Optional<String> ignored,
             @JsonProperty(value = "records") final List<TopicRecord.RecordBuilder> records) {
-        this(
-                buildRecords(
-                        requireNonNull(clusterName, "clusterName"),
-                        requireNonNull(topicName, "topicName"),
-                        requireNonNull(records, "records")),
-                LocationAware.UNKNOWN_LOCATION);
-    }
+        this.records = List.copyOf(buildRecords(
+                requireNonNull(clusterName, "clusterName"),
+                requireNonNull(topicName, "topicName"),
+                requireNonNull(records, "records")));
 
-    private TopicInput(final List<TopicRecord> records, final URI location) {
-        this.location = requireNonNull(location, "location");
-        this.records = List.copyOf(requireNonNull(records, "records"));
         if (records.isEmpty()) {
             throw new IllegalArgumentException("At least one record is required");
         }
@@ -56,15 +48,5 @@ public final class TopicInput implements Input, LocationAware<TopicInput> {
 
     public List<TopicRecord> records() {
         return List.copyOf(records);
-    }
-
-    @Override
-    public URI location() {
-        return location;
-    }
-
-    @Override
-    public TopicInput withLocation(final URI location) {
-        return new TopicInput(records, location);
     }
 }

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicInputHandlerTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicInputHandlerTest.java
@@ -93,7 +93,6 @@ class TopicInputHandlerTest {
                         Optional3.of("1"));
 
         when(input.records()).thenReturn(List.of(record0, record1));
-        when(input.location()).thenReturn(URI.create("input:///location"));
 
         when(clientsExt.producer("cluster-a")).thenReturn(producerA);
         when(clientsExt.producer("cluster-b")).thenReturn(producerB);


### PR DESCRIPTION
The locations of the topic input and expectations are not used. Instead the location of the records they contain is used.

So lets remove unused code...

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended