### PR TITLE
Fail if consumed records are out of order

### DIFF
--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/ClientExtensionFunctionalTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/ClientExtensionFunctionalTest.java
@@ -61,7 +61,7 @@ class ClientExtensionFunctionalTest {
 
     @Container
     private static final KafkaContainer KAFKA_CLUSTER =
-            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.4"))
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.7"))
                     .withStartupAttempts(3)
                     .withStartupTimeout(Duration.ofSeconds(90))
                     .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "true");

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClientFunctionalTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClientFunctionalTest.java
@@ -66,14 +66,14 @@ class KafkaTopicClientFunctionalTest {
 
     @Container
     private static final KafkaContainer DEFAULT_CLUSTER =
-            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.4"))
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.7"))
                     .withStartupAttempts(3)
                     .withStartupTimeout(Duration.ofSeconds(90))
                     .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
 
     @Container
     private static final KafkaContainer OTHER_CLUSTER =
-            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.4"))
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.7"))
                     .withStartupAttempts(3)
                     .withStartupTimeout(Duration.ofSeconds(90))
                     .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");

--- a/test-extension/README.md
+++ b/test-extension/README.md
@@ -1,3 +1,111 @@
 # Creek Kafka System Test Extension
 
 A Creek system test extension for system testing Kafka based microservices.
+
+## Test model
+
+The extension registers the following model subtypes to support system testing of Kafka based microservices:
+
+### Option model extensions
+
+The behaviour of the Kafka test extension can be controlled via the `creek/kafka-option@1` option type.  
+This option type defines the following:
+
+| Property name    | Property type           | Description                                                                                                                                                                                                                                                              |
+|------------------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `outputOrdering` | Enum (`NONE`, `BY_KEY`) | Controls the ordering requirements for the expected output records on the same topic. Valid values are:<br>`None`: records can be in any order.<br>`BY_KEY`: record expectations that share the same key must be received in the order defined.<br>**Default**: `BY_KEY` |
+
+For example, the following defines a suite that turns off ordering requirements for expectation records:
+
+##### **`no-ordering-suite.yml`**
+```yaml
+---
+name: Test suite with expectation ordering disabled
+options:
+  - !creek/kafka-options@1
+    outputOrdering: NONE
+services:
+  - some-service
+tests:
+  - name: test 1
+    inputs:
+      - some_input
+    expectations:
+      - unordered_output
+```
+
+### Input model extensions
+
+The Kafka test extension registers a `creek/kafka-topic` input model extension. 
+This can be used to define seed and input records to be produced to Kafka.
+It supports the following properties:
+
+| Property Name | Property Type           | Description                                                                                                                                                            |
+|---------------|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| topic         | String                  | (Optional) A default topic name that will be used for any `records` that do not define their own. If not set, any records without a topic set will result in an error. |
+| cluster       | String                  | (Optional) A default cluster name that will be used for any `records` that do not define their own. If not set, any records will default to the default cluster name.  |
+| notes         | String                  | (Optional) A notes field. Ignored by the system tests. Can be used to document intent.                                                                                 |
+| records       | Array of `TopicRecord`s | (Required) The records to produce to Kafka.                                                                                                                            |
+
+Each `TopicRecord` supports the following properties:
+
+| Property Name | Property Type | Description                                                                                                                                                             |
+|---------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| topic         | String        | (Optional) The topic to produce the record to. If not set, the file level default `topic` will be used. Neither being set will result in an error.                      |
+| cluster       | String        | (Optional) The cluster to produce the record to. If not set, the file level default `cluster` will be used. If neither are set the `default` cluster will be used.      |
+| key           | Any           | (Optional) The key of the record to produce. The type can be any type supported by the topic's key serde. If not set, the produced record will have a `null` key.       |
+| value         | Any           | (Optional) The value of the record to produce. The type can be any type supported by the topic's value serde. If not set, the produced record will have a `null` value. |
+| notes         | String        | (Optional) An optional notes field. Ignored by the system tests. Can be used to document intent.                                                                        |
+
+For example, the following defines an input that will produce two records to an `input` topic on the `default` cluster:
+
+##### **`inputs/produce_input.yml`**
+```yaml
+---
+!creek/kafka-topic
+topic: input
+records:
+  - key: 1
+    value: foo
+  - notes: this record has no value set. The record produced to kafka will therefore have a null value.
+    key: 2    
+```
+
+### Expectation model extensions
+
+The Kafka test extension registers a `creek/kafka-topic` expectation model extension.
+This can be used to define the records services are expected to produce to Kafka.
+It supports the following properties:
+
+| Property Name | Property Type           | Description                                                                                                                                                            |
+|---------------|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| topic         | String                  | (Optional) A default topic name that will be used for any `records` that do not define their own. If not set, any records without a topic set will result in an error. |
+| cluster       | String                  | (Optional) A default cluster name that will be used for any `records` that do not define their own. If not set, any records will default to the default cluster name.  |
+| notes         | String                  | (Optional) A notes field. Ignored by the system tests. Can be used to document intent.                                                                                 |
+| records       | Array of `TopicRecord`s | (Required) The records to produce to Kafka.                                                                                                                            |
+
+Each `TopicRecord` supports the following properties:
+
+| Property Name | Property Type | Description                                                                                                                                                          |
+|---------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| topic         | String        | (Optional) The topic to consume the record from. If not set, the file level default `topic` will be used. Neither being set will result in an error.                 |
+| cluster       | String        | (Optional) The cluster to consume the record from. If not set, the file level default `cluster` will be used. If neither are set the `default` cluster will be used. |
+| key           | Any           | (Optional) The expected key of the record. If not set, the consumed record's key will be ignored.                                                                    |
+| value         | Any           | (Optional) The expected value of the record. If not set, the consumed record's value will be ignored.                                                                |
+| notes         | String        | (Optional) An optional notes field. Ignored by the system tests. Can be used to document intent.                                                                     |
+
+For example, the following defines an expectation that two records will be produced to the `output` topic on the `primary` cluster:
+
+##### **`inputs/produce_input.yml`**
+```yaml
+---
+!creek/kafka-topic
+topic: input
+cluster: primary
+records:
+  - notes: this record expectation does not define any value, meaning the value is ignored, i.e. it can hold any value.
+    key: 1    
+  - notes: this record expectation explicitly requires the value to be null
+    key: 2
+    value: ~
+```

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtension.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtension.java
@@ -26,6 +26,7 @@ import org.creekservice.api.system.test.extension.test.model.TestModelContainer;
 import org.creekservice.internal.kafka.extension.ClientsExtension;
 import org.creekservice.internal.kafka.streams.test.extension.handler.TopicExpectationHandler;
 import org.creekservice.internal.kafka.streams.test.extension.handler.TopicInputHandler;
+import org.creekservice.internal.kafka.streams.test.extension.model.TestOptions;
 import org.creekservice.internal.kafka.streams.test.extension.model.TopicExpectation;
 import org.creekservice.internal.kafka.streams.test.extension.model.TopicInput;
 import org.creekservice.internal.kafka.streams.test.extension.testsuite.StartKafkaTestListener;
@@ -70,8 +71,9 @@ public final class KafkaTestExtension implements CreekTestExtension {
     public static void initializeModel(
             final TestModelContainer model, final ClientsExtension clientsExt) {
         model.addInput(TopicInput.class, new TopicInputHandler(clientsExt))
-                .withName("creek/kafka-topic");
+                .withName(TopicInput.NAME);
         model.addExpectation(TopicExpectation.class, new TopicExpectationHandler(clientsExt))
-                .withName("creek/kafka-topic");
+                .withName(TopicExpectation.NAME);
+        model.addOption(TestOptions.class).withName(TestOptions.NAME);
     }
 }

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/MatchResult.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/MatchResult.java
@@ -69,9 +69,9 @@ final class MatchResult {
     static final class Mismatched {
 
         private final ConsumedRecord actual;
-        private final MismatchDescription mismatchDescription;
+        private final String mismatchDescription;
 
-        Mismatched(final ConsumedRecord actual, final MismatchDescription mismatchDescription) {
+        Mismatched(final ConsumedRecord actual, final String mismatchDescription) {
             this.actual = requireNonNull(actual, "actual");
             this.mismatchDescription = requireNonNull(mismatchDescription, "mismatchDescription");
         }
@@ -80,7 +80,7 @@ final class MatchResult {
             return actual;
         }
 
-        public MismatchDescription mismatchDescription() {
+        public String mismatchDescription() {
             return mismatchDescription;
         }
     }

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TestOptionsAccessor.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TestOptionsAccessor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.streams.test.extension.handler;
+
+
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.creekservice.api.system.test.extension.test.model.ExpectationHandler.ExpectationOptions;
+import org.creekservice.internal.kafka.streams.test.extension.model.TestOptions;
+
+public final class TestOptionsAccessor {
+
+    private TestOptionsAccessor() {}
+
+    public static TestOptions get(final ExpectationOptions options) {
+        final List<TestOptions> userSupplied = options.get(TestOptions.class);
+        switch (userSupplied.size()) {
+            case 0:
+                return TestOptions.defaults();
+            case 1:
+                return userSupplied.get(0);
+            default:
+                final List<URI> locations =
+                        userSupplied.stream()
+                                .map(TestOptions::location)
+                                .collect(Collectors.toList());
+                throw new IllegalArgumentException(
+                        "Test suite should only define single '"
+                                + TestOptions.NAME
+                                + "' option. locations: "
+                                + locations);
+        }
+    }
+}

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicInputHandler.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicInputHandler.java
@@ -47,7 +47,7 @@ public final class TopicInputHandler implements InputHandler<TopicInput> {
     }
 
     @Override
-    public void process(final TopicInput input) {
+    public void process(final TopicInput input, final InputOptions options) {
         input.records().forEach(this::process);
     }
 

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicVerifier.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicVerifier.java
@@ -18,12 +18,12 @@ package org.creekservice.internal.kafka.streams.test.extension.handler;
 
 import static java.lang.System.lineSeparator;
 import static java.util.Objects.requireNonNull;
+import static org.creekservice.internal.kafka.streams.test.extension.util.ErrorMsgUtil.formatList;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import org.creekservice.api.base.annotation.VisibleForTesting;
 import org.creekservice.api.system.test.extension.test.model.ExpectationHandler;
@@ -31,6 +31,7 @@ import org.creekservice.api.system.test.extension.test.model.ExpectationHandler.
 import org.creekservice.internal.kafka.streams.test.extension.handler.MatchResult.Unmatched;
 
 final class TopicVerifier implements ExpectationHandler.Verifier {
+
     private static final Duration EXTRA_RECORD_TIMEOUT = Duration.ofSeconds(1);
 
     private final Clock clock;
@@ -97,10 +98,10 @@ final class TopicVerifier implements ExpectationHandler.Verifier {
                         + " expected record(s) not found."
                         + lineSeparator()
                         + "Unmatched records: "
-                        + formattedArray(unmatched)
+                        + formatList(unmatched)
                         + lineSeparator()
                         + "Matched records: "
-                        + formattedArray(result.matched()));
+                        + formatList(result.matched()));
     }
 
     private static AssertionError extrasError(final List<ConsumedRecord> extras) {
@@ -108,7 +109,7 @@ final class TopicVerifier implements ExpectationHandler.Verifier {
                 "Additional records were produced."
                         + lineSeparator()
                         + "Unmatched records: "
-                        + formattedArray(extras));
+                        + formatList(extras));
     }
 
     private static String format(final Unmatched unmatched) {
@@ -122,19 +123,6 @@ final class TopicVerifier implements ExpectationHandler.Verifier {
                 + unmatched.expected()
                 + lineSeparator()
                 + "\tActual: "
-                + formattedArray(mismatchReasons, 2);
-    }
-
-    static String formattedArray(final List<?> list) {
-        return formattedArray(list, 1);
-    }
-
-    private static String formattedArray(final List<?> list, final int indentLevel) {
-        final String indent = "\t".repeat(indentLevel);
-        final String finalIndent = "\t".repeat(indentLevel - 1);
-        return list.stream()
-                .map(Objects::toString)
-                .map(s -> lineSeparator() + indent + s)
-                .collect(Collectors.joining(",", "[", lineSeparator() + finalIndent + "]"));
+                + formatList(mismatchReasons, 1);
     }
 }

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TestOptions.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TestOptions.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.streams.test.extension.model;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.net.URI;
+import java.util.Optional;
+import org.creekservice.api.system.test.extension.test.model.LocationAware;
+import org.creekservice.api.system.test.extension.test.model.Option;
+
+/** Test model extension to allow users to customise how this test extension operates. */
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+public final class TestOptions implements Option, LocationAware<TestOptions> {
+
+    public static final String NAME = "creek/kafka-options@1";
+
+    private static final TestOptions DEFAULTS = new TestOptions(Optional.empty());
+
+    public enum OutputOrdering {
+        /** Topic records can be in any order. */
+        NONE,
+
+        /**
+         * Records sharing the same key must be received in the same order they are defined in the
+         * expectations.
+         */
+        BY_KEY
+    }
+
+    private final URI location;
+    private final OutputOrdering outputOrdering;
+
+    public static TestOptions defaults() {
+        return DEFAULTS;
+    }
+
+    @SuppressWarnings("unused") // Invoked by Jackson via reflection
+    public TestOptions(
+            @JsonProperty("outputOrdering") final Optional<OutputOrdering> outputOrdering) {
+        this(outputOrdering.orElse(OutputOrdering.BY_KEY), LocationAware.UNKNOWN_LOCATION);
+    }
+
+    private TestOptions(final OutputOrdering outputOrdering, final URI location) {
+        this.outputOrdering = requireNonNull(outputOrdering, "outputOrdering");
+        this.location = requireNonNull(location, "location");
+    }
+
+    public OutputOrdering outputOrdering() {
+        return outputOrdering;
+    }
+
+    @Override
+    public TestOptions withLocation(final URI location) {
+        return new TestOptions(outputOrdering, location);
+    }
+
+    @Override
+    public URI location() {
+        return location;
+    }
+}

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicExpectation.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicExpectation.java
@@ -27,6 +27,8 @@ import org.creekservice.api.system.test.extension.test.model.Expectation;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public final class TopicExpectation implements Expectation {
 
+    public static final String NAME = "creek/kafka-topic";
+
     private final List<TopicRecord> records;
 
     @SuppressWarnings("unused") // Invoked by Jackson via reflection

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicInput.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicInput.java
@@ -27,6 +27,8 @@ import org.creekservice.api.system.test.extension.test.model.Input;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public final class TopicInput implements Input {
 
+    public static final String NAME = "creek/kafka-topic";
+
     private final List<TopicRecord> records;
 
     @SuppressWarnings("unused") // Invoked by Jackson via reflection

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDef.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDef.java
@@ -49,7 +49,7 @@ final class KafkaContainerDef implements ServiceDefinition {
     @Override
     public String dockerImage() {
         // Should be configurable: https://github.com/creek-service/creek-kafka/issues/82
-        return "confluentinc/cp-kafka:6.2.4";
+        return "confluentinc/cp-kafka:6.2.7";
     }
 
     @Override

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/util/ErrorMsgUtil.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/util/ErrorMsgUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.streams.test.extension.util;
+
+import static java.lang.System.lineSeparator;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public final class ErrorMsgUtil {
+
+    private ErrorMsgUtil() {}
+
+    public static String formatList(final List<?> list) {
+        return formatList(list, 0);
+    }
+
+    public static String formatList(final List<?> list, final int indentLevel) {
+        final String indent = "\t".repeat(indentLevel + 1);
+        final String finalIndent = "\t".repeat(indentLevel);
+        return list.stream()
+                .map(Objects::toString)
+                .map(s -> lineSeparator() + indent + s)
+                .collect(Collectors.joining(",", "[", lineSeparator() + finalIndent + "]"));
+    }
+}

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/util/Optional3.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/util/Optional3.java
@@ -97,6 +97,10 @@ public final class Optional3<T> {
         return hasValue ? value.orElse(ifNull) : ifNotProvided;
     }
 
+    public T orElseThrow() {
+        return value.orElseThrow();
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtensionFunctionalTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtensionFunctionalTest.java
@@ -62,24 +62,28 @@ class KafkaTestExtensionFunctionalTest {
         // Then:
         assertThat(result.toString(), result.passed(), is(false));
         assertThat(resultsDir.resolve("TEST-expectation_failures.xml"), is(regularFile()));
-        assertThat(failureMessage(result, 0), containsString("Additional records"));
-        assertThat(failureMessage(result, 1), containsString("1 expected record(s) not found"));
+        assertThat(failureMessage(result, 0, 0), containsString("Additional records"));
+        assertThat(failureMessage(result, 0, 1), containsString("1 expected record(s) not found"));
         assertThat(
-                failureMessage(result, 1),
+                failureMessage(result, 0, 1),
                 containsString("(Mismatch@key@char5, expected: Long(-2), actual: Long(2))"));
-        assertThat(failureMessage(result, 2), containsString("1 expected record(s) not found"));
+        assertThat(failureMessage(result, 0, 2), containsString("1 expected record(s) not found"));
         assertThat(
-                failureMessage(result, 2),
+                failureMessage(result, 0, 2),
                 containsString("(Mismatch@key@char0, expected: <empty>, actual: Long(2))"));
-        assertThat(failureMessage(result, 3), containsString("1 expected record(s) not found"));
+        assertThat(failureMessage(result, 0, 3), containsString("1 expected record(s) not found"));
         assertThat(
-                failureMessage(result, 3),
+                failureMessage(result, 0, 3),
                 containsString(
                         "(Mismatch@value@char7, expected: String(dad), actual: String(mum))"));
-        assertThat(failureMessage(result, 4), containsString("1 expected record(s) not found"));
+        assertThat(failureMessage(result, 0, 4), containsString("1 expected record(s) not found"));
         assertThat(
-                failureMessage(result, 4),
+                failureMessage(result, 0, 4),
                 containsString("(Mismatch@value@char0, expected: <empty>, actual: String(mum))"));
+        assertThat(failureMessage(result, 1, 0), containsString("1 expected record(s) not found."));
+        assertThat(
+                failureMessage(result, 1, 0),
+                containsString("(Records match, but the order is wrong)"));
     }
 
     @Test
@@ -130,20 +134,21 @@ class KafkaTestExtensionFunctionalTest {
                                 + "Failed to deserialize record key. topic: output, partition: 0, offset: 0"));
     }
 
-    private static String failureMessage(final TestExecutionResult result, final int index) {
-        assertThat(result.toString(), result.results(), hasSize(1));
+    private static String failureMessage(
+            final TestExecutionResult result, final int suiteIndex, final int caseIndex) {
+        assertThat(result.toString(), result.results(), hasSize(greaterThan(suiteIndex)));
         assertThat(
                 result.toString(),
-                result.results().get(0).testCases(),
-                hasSize(greaterThan(index)));
+                result.results().get(suiteIndex).testCases(),
+                hasSize(greaterThan(caseIndex)));
         assertThat(
                 result.toString(),
-                result.results().get(0).testCases().get(index).failure(),
+                result.results().get(suiteIndex).testCases().get(caseIndex).failure(),
                 not(Optional.empty()));
         return result.results()
-                .get(0)
+                .get(suiteIndex)
                 .testCases()
-                .get(index)
+                .get(caseIndex)
                 .failure()
                 .map(Throwable::getMessage)
                 .orElse("");

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtensionTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtensionTest.java
@@ -31,7 +31,10 @@ import static org.mockito.Mockito.when;
 import org.creekservice.api.kafka.extension.KafkaClientsExtensionProvider;
 import org.creekservice.api.system.test.extension.CreekSystemTest;
 import org.creekservice.internal.kafka.extension.ClientsExtension;
+import org.creekservice.internal.kafka.streams.test.extension.handler.TopicExpectationHandler;
 import org.creekservice.internal.kafka.streams.test.extension.handler.TopicInputHandler;
+import org.creekservice.internal.kafka.streams.test.extension.model.TestOptions;
+import org.creekservice.internal.kafka.streams.test.extension.model.TopicExpectation;
 import org.creekservice.internal.kafka.streams.test.extension.model.TopicInput;
 import org.creekservice.internal.kafka.streams.test.extension.testsuite.StartKafkaTestListener;
 import org.creekservice.internal.kafka.streams.test.extension.testsuite.TearDownTestListener;
@@ -112,5 +115,30 @@ class KafkaTestExtensionTest {
         // Then:
         verify(api.tests().model().addInput(eq(TopicInput.class), isA(TopicInputHandler.class)))
                 .withName("creek/kafka-topic");
+    }
+
+    @Test
+    void shouldRegisterTopicExpectationModel() {
+        // When:
+        ext.initialize(api);
+
+        // Then:
+        verify(
+                        api.tests()
+                                .model()
+                                .addExpectation(
+                                        eq(TopicExpectation.class),
+                                        isA(TopicExpectationHandler.class)))
+                .withName("creek/kafka-topic");
+    }
+
+    @Test
+    void shouldRegisterOptionModel() {
+        // When:
+        ext.initialize(api);
+
+        // Then:
+        verify(api.tests().model().addOption(eq(TestOptions.class)))
+                .withName("creek/kafka-options@1");
     }
 }

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TestOptionsAccessorTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TestOptionsAccessorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.streams.test.extension.handler;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.List;
+import org.creekservice.api.system.test.extension.test.model.ExpectationHandler.ExpectationOptions;
+import org.creekservice.internal.kafka.streams.test.extension.model.TestOptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TestOptionsAccessorTest {
+
+    @Mock private ExpectationOptions options;
+    @Mock private TestOptions testOptions;
+
+    @Test
+    void shouldReturnDefaultOptions() {
+        // When:
+        final TestOptions result = TestOptionsAccessor.get(options);
+
+        // Then:
+        assertThat(result, is(TestOptions.defaults()));
+    }
+
+    @Test
+    void shouldReturnUserSuppliedOptions() {
+        // Given:
+        when(options.get(TestOptions.class)).thenReturn(List.of(testOptions));
+
+        // When:
+        final TestOptions result = TestOptionsAccessor.get(options);
+
+        // Then:
+        assertThat(result, is(testOptions));
+    }
+
+    @Test
+    void shouldThrowOnDuplicateOptions() {
+        // Given:
+        when(options.get(TestOptions.class)).thenReturn(List.of(testOptions, testOptions));
+
+        when(testOptions.location())
+                .thenReturn(URI.create("file:///loc0"), URI.create("file:///loc1"));
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        IllegalArgumentException.class, () -> TestOptionsAccessor.get(options));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is(
+                        "Test suite should only define single 'creek/kafka-options@1' option. "
+                                + "locations: [file:///loc0, file:///loc1]"));
+    }
+}

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicInputHandlerTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicInputHandlerTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.creekservice.api.kafka.extension.resource.KafkaTopic;
+import org.creekservice.api.system.test.extension.test.model.InputHandler.InputOptions;
 import org.creekservice.internal.kafka.extension.ClientsExtension;
 import org.creekservice.internal.kafka.streams.test.extension.model.TopicInput;
 import org.creekservice.internal.kafka.streams.test.extension.model.TopicRecord;
@@ -62,6 +63,7 @@ class TopicInputHandlerTest {
 
     @Mock private TypeCoercer coercer;
     @Mock private TopicInput input;
+    @Mock private InputOptions options;
     @Mock private Producer<byte[], byte[]> producerA;
     @Mock private Producer<byte[], byte[]> producerB;
 
@@ -133,7 +135,7 @@ class TopicInputHandlerTest {
         when(input.records()).thenReturn(List.of());
 
         // When:
-        handler.process(input);
+        handler.process(input, options);
         handler.flush();
 
         // Then:
@@ -143,7 +145,7 @@ class TopicInputHandlerTest {
     @Test
     void shouldGetTopic() {
         // When:
-        handler.process(input);
+        handler.process(input, options);
 
         // Then:
         verify(clientsExt).topic("cluster-a", "topic-a");
@@ -153,7 +155,7 @@ class TopicInputHandlerTest {
     @Test
     void shouldGetProducer() {
         // When:
-        handler.process(input);
+        handler.process(input, options);
 
         // Then:
         verify(clientsExt).producer("cluster-a");
@@ -163,7 +165,7 @@ class TopicInputHandlerTest {
     @Test
     void shouldCoerceKeys() {
         // When:
-        handler.process(input);
+        handler.process(input, options);
 
         // Then:
         verify(coercer).coerce(87, Integer.class);
@@ -173,7 +175,7 @@ class TopicInputHandlerTest {
     @Test
     void shouldCoerceValues() {
         // When:
-        handler.process(input);
+        handler.process(input, options);
 
         // Then:
         verify(coercer).coerce(0, String.class);
@@ -183,7 +185,7 @@ class TopicInputHandlerTest {
     @Test
     void shouldSerializeKeys() {
         // When:
-        handler.process(input);
+        handler.process(input, options);
 
         // Then:
         verify(topicA).serializeKey(88);
@@ -193,7 +195,7 @@ class TopicInputHandlerTest {
     @Test
     void shouldSerializeValues() {
         // When:
-        handler.process(input);
+        handler.process(input, options);
 
         // Then:
         verify(topicA).serializeValue("coerced-0");
@@ -203,7 +205,7 @@ class TopicInputHandlerTest {
     @Test
     void shouldSendByCluster() {
         // When:
-        handler.process(input);
+        handler.process(input, options);
 
         // Then:
         verify(producerA)
@@ -232,7 +234,7 @@ class TopicInputHandlerTest {
         when(input.records()).thenReturn(List.of(record0, record1));
 
         // When:
-        handler.process(input);
+        handler.process(input, options);
 
         // Then:
         verify(producerA)
@@ -244,7 +246,7 @@ class TopicInputHandlerTest {
     @Test
     void shouldFlushByCluster() {
         // Given:
-        handler.process(input);
+        handler.process(input, options);
 
         // When:
         handler.flush();
@@ -274,7 +276,7 @@ class TopicInputHandlerTest {
         when(input.records()).thenReturn(List.of(record0, record1));
 
         // Given:
-        handler.process(input);
+        handler.process(input, options);
 
         // When:
         handler.flush();
@@ -287,7 +289,7 @@ class TopicInputHandlerTest {
     @Test
     void shouldFlushOnlyOnce() {
         // Given:
-        handler.process(input);
+        handler.process(input, options);
         handler.flush();
         clearInvocations(producerA);
 
@@ -318,7 +320,7 @@ class TopicInputHandlerTest {
         when(input.records()).thenReturn(List.of(record0, record1));
 
         // When:
-        handler.process(input);
+        handler.process(input, options);
 
         // Then:
         verify(producerA).send(new ProducerRecord<>("topic-a", null, SERIALIZED_VALUE_A));
@@ -345,7 +347,7 @@ class TopicInputHandlerTest {
         when(input.records()).thenReturn(List.of(record0, record1));
 
         // When:
-        handler.process(input);
+        handler.process(input, options);
 
         // Then:
         verify(producerA).send(new ProducerRecord<>("topic-a", SERIALIZED_KEY_A, null));
@@ -359,7 +361,8 @@ class TopicInputHandlerTest {
         when(clientsExt.topic(any(), any())).thenThrow(cause);
 
         // When:
-        final Exception e = assertThrows(RuntimeException.class, () -> handler.process(input));
+        final Exception e =
+                assertThrows(RuntimeException.class, () -> handler.process(input, options));
 
         // Then:
         assertThat(
@@ -377,7 +380,8 @@ class TopicInputHandlerTest {
         doThrow(cause).when(coercer).coerce(eq(123L), any());
 
         // When:
-        final Exception e = assertThrows(RuntimeException.class, () -> handler.process(input));
+        final Exception e =
+                assertThrows(RuntimeException.class, () -> handler.process(input, options));
 
         // Then:
         assertThat(
@@ -396,7 +400,8 @@ class TopicInputHandlerTest {
         doThrow(cause).when(coercer).coerce(any(), eq(String.class));
 
         // When:
-        final Exception e = assertThrows(RuntimeException.class, () -> handler.process(input));
+        final Exception e =
+                assertThrows(RuntimeException.class, () -> handler.process(input, options));
 
         // Then:
         assertThat(
@@ -415,7 +420,8 @@ class TopicInputHandlerTest {
         doThrow(cause).when(topicB).serializeKey(any());
 
         // When:
-        final Exception e = assertThrows(RuntimeException.class, () -> handler.process(input));
+        final Exception e =
+                assertThrows(RuntimeException.class, () -> handler.process(input, options));
 
         // Then:
         assertThat(
@@ -431,7 +437,8 @@ class TopicInputHandlerTest {
         doThrow(cause).when(topicB).serializeValue(any());
 
         // When:
-        final Exception e = assertThrows(RuntimeException.class, () -> handler.process(input));
+        final Exception e =
+                assertThrows(RuntimeException.class, () -> handler.process(input, options));
 
         // Then:
         assertThat(
@@ -444,7 +451,7 @@ class TopicInputHandlerTest {
     @Test
     void shouldThrowIfFlushThrows() {
         // Given:
-        handler.process(input);
+        handler.process(input, options);
 
         final RuntimeException cause = new RuntimeException("boom");
         doThrow(cause).when(producerA).flush();

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicVerifierTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicVerifierTest.java
@@ -125,12 +125,10 @@ class TopicVerifierTest {
         final TopicRecord expected = mock(TopicRecord.class, withSettings().name("e-record"));
         final Unmatched unmatched = mock(Unmatched.class);
         final Mismatched mismatched = mock(Mismatched.class);
-        final MismatchDescription mismatchDescription =
-                mock(MismatchDescription.class, withSettings().name("mismatch details"));
         when(unmatched.expected()).thenReturn(expected);
         when(unmatched.mismatches()).thenReturn(List.of(mismatched));
         when(mismatched.actual()).thenReturn(rec1);
-        when(mismatched.mismatchDescription()).thenReturn(mismatchDescription);
+        when(mismatched.mismatchDescription()).thenReturn("mismatch details");
 
         when(result.matched()).thenReturn(List.of(rec0));
         when(result.unmatched()).thenReturn(List.of(unmatched));

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDefTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDefTest.java
@@ -97,7 +97,7 @@ class KafkaContainerDefTest {
 
     @Test
     void shouldUseRightDockerImage() {
-        assertThat(def.dockerImage(), is("confluentinc/cp-kafka:6.2.4"));
+        assertThat(def.dockerImage(), is("confluentinc/cp-kafka:6.2.7"));
     }
 
     @Test

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/StartKafkaTestListenerFunctionalTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/StartKafkaTestListenerFunctionalTest.java
@@ -221,7 +221,7 @@ class StartKafkaTestListenerFunctionalTest {
                     .all()
                     .get(1, TimeUnit.HOURS);
         } catch (ExecutionException | TimeoutException | InterruptedException e) {
-            throw new AssertionError("Failed to create topic");
+            throw new AssertionError("Failed to create topic", e);
         }
     }
 

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/util/ErrorMsgUtilTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/util/ErrorMsgUtilTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.streams.test.extension.util;
+
+import static java.lang.System.lineSeparator;
+import static org.creekservice.internal.kafka.streams.test.extension.util.ErrorMsgUtil.formatList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ErrorMsgUtilTest {
+
+    @Test
+    void shouldFormatList() {
+        // Given:
+        final List<?> list = List.of("hello", 22, 19L);
+        assertThat(
+                formatList(list),
+                is(
+                        "["
+                                + lineSeparator()
+                                + "\thello,"
+                                + lineSeparator()
+                                + "\t22,"
+                                + lineSeparator()
+                                + "\t19"
+                                + lineSeparator()
+                                + "]"));
+    }
+
+    @Test
+    void shouldFormatListWithIndent() {
+        // Given:
+        final List<?> list = List.of("hello", 22, 19L);
+        assertThat(
+                formatList(list, 2),
+                is(
+                        "["
+                                + lineSeparator()
+                                + "\t\t\thello,"
+                                + lineSeparator()
+                                + "\t\t\t22,"
+                                + lineSeparator()
+                                + "\t\t\t19"
+                                + lineSeparator()
+                                + "\t\t]"));
+    }
+}

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/util/Optional3Test.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/util/Optional3Test.java
@@ -85,6 +85,14 @@ class Optional3Test {
         assertThat(of(8).orElse(1, 2), is(8));
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    void shouldOrElseThrow() {
+        assertThrows(NoSuchElementException.class, () -> notProvided().orElseThrow());
+        assertThrows(NoSuchElementException.class, () -> explicitlyNull().orElseThrow());
+        assertThat(of(8).orElseThrow(), is(8));
+    }
+
     @Test
     void shouldToString() {
         assertThat(notProvided().toString(), is("<not-set>"));

--- a/test-extension/src/test/resources/testcases/expectation_failure/expectations/additional_output.yml
+++ b/test-extension/src/test/resources/testcases/expectation_failure/expectations/additional_output.yml
@@ -5,5 +5,5 @@ records:
   - key: 1
     value: hello
     notes: record with key 2 is missing form this list, meaning it will be reported as extra.
-  - key: 3
-    value: hello
+  - key: 1
+    value: bye

--- a/test-extension/src/test/resources/testcases/expectation_failure/expectations/wrong_key.yml
+++ b/test-extension/src/test/resources/testcases/expectation_failure/expectations/wrong_key.yml
@@ -7,5 +7,5 @@ records:
   - notes: this has the wrong key
     key: -2
     value: mum
-  - key: 3
-    value: hello
+  - key: 1
+    value: bye

--- a/test-extension/src/test/resources/testcases/expectation_failure/expectations/wrong_key_order.yml
+++ b/test-extension/src/test/resources/testcases/expectation_failure/expectations/wrong_key_order.yml
@@ -1,0 +1,12 @@
+---
+!creek/kafka-topic
+topic: output
+records:
+  - notes: this should not cause any issues as its the only record on this key
+    key: 2
+    value: mum
+  - notes: expectation out of order, so should fail on ordering.
+    key: 1
+    value: bye
+  - key: 1
+    value: hello

--- a/test-extension/src/test/resources/testcases/expectation_failure/expectations/wrong_null_key.yml
+++ b/test-extension/src/test/resources/testcases/expectation_failure/expectations/wrong_null_key.yml
@@ -7,5 +7,5 @@ records:
   - notes: this has a null key, which is wrong.
     key: ~
     value: mum
-  - key: 3
-    value: hello
+  - key: 1
+    value: bye

--- a/test-extension/src/test/resources/testcases/expectation_failure/expectations/wrong_null_value.yml
+++ b/test-extension/src/test/resources/testcases/expectation_failure/expectations/wrong_null_value.yml
@@ -7,5 +7,5 @@ records:
   - notes: this has a null key, which is wrong.
     key: 2
     value: ~
-  - key: 3
-    value: hello
+  - key: 1
+    value: bye

--- a/test-extension/src/test/resources/testcases/expectation_failure/expectations/wrong_value.yml
+++ b/test-extension/src/test/resources/testcases/expectation_failure/expectations/wrong_value.yml
@@ -7,5 +7,5 @@ records:
   - notes: this has the wrong value
     key: 2
     value: dad
-  - key: 3
-    value: hello
+  - key: 1
+    value: bye

--- a/test-extension/src/test/resources/testcases/expectation_failure/inputs/input.yml
+++ b/test-extension/src/test/resources/testcases/expectation_failure/inputs/input.yml
@@ -6,5 +6,5 @@ records:
     value: 1
   - key: mum
     value: 2
-  - key: hello
-    value: 3
+  - key: bye
+    value: 1

--- a/test-extension/src/test/resources/testcases/expectation_failure/ordered_by_key.yml
+++ b/test-extension/src/test/resources/testcases/expectation_failure/ordered_by_key.yml
@@ -1,0 +1,13 @@
+---
+name: order by key
+services:
+  - test-service
+options:
+  - !creek/kafka-options@1
+    outputOrdering: BY_KEY
+tests:
+  - name: out of order
+    inputs:
+      - input
+    expectations:
+      - wrong_key_order

--- a/test-extension/src/test/resources/testcases/expectation_failure/suite.yml
+++ b/test-extension/src/test/resources/testcases/expectation_failure/suite.yml
@@ -1,5 +1,5 @@
 ---
-name: expectation failures
+name: main
 services:
   - test-service
 tests:

--- a/test-extension/src/test/resources/testcases/passing/expectations/output.yml
+++ b/test-extension/src/test/resources/testcases/passing/expectations/output.yml
@@ -2,6 +2,9 @@
 !creek/kafka-topic
 topic: output
 records:
+  - notes: expectation out of order, but this should not cause a failure as ordering is not enabled.
+    key: 1
+    value: bye
   - notes: record expectation without a key, i.e. don't care what key is
     value: hello
   - notes: record expectation with key and value

--- a/test-extension/src/test/resources/testcases/passing/expectations/output_in_order_1.yml
+++ b/test-extension/src/test/resources/testcases/passing/expectations/output_in_order_1.yml
@@ -1,0 +1,16 @@
+---
+!creek/kafka-topic
+topic: output
+records:
+  - key: 1
+    value: hello
+  - key: 2
+    value: mum
+  - key: 3
+    value: some
+  - key: 4
+    value: any
+  - key: 5
+    value: ~
+  - key: ~
+    value: no_v

--- a/test-extension/src/test/resources/testcases/passing/expectations/output_in_order_2.yml
+++ b/test-extension/src/test/resources/testcases/passing/expectations/output_in_order_2.yml
@@ -1,0 +1,7 @@
+---
+!creek/kafka-topic
+topic: output
+notes: having this in a separate file tests that the records from two files are combined in the right order.
+records:
+  - key: 1
+    value: bye

--- a/test-extension/src/test/resources/testcases/passing/inputs/input.yml
+++ b/test-extension/src/test/resources/testcases/passing/inputs/input.yml
@@ -14,3 +14,5 @@ records:
     value: 5
   - notes: null value
     key: no_v
+  - key: bye
+    value: 1

--- a/test-extension/src/test/resources/testcases/passing/ordered_by_key.yml
+++ b/test-extension/src/test/resources/testcases/passing/ordered_by_key.yml
@@ -1,0 +1,14 @@
+---
+name: order by key
+services:
+  - test-service
+options:
+  - !creek/kafka-options@1
+    outputOrdering: BY_KEY
+tests:
+  - name: should verify key ordering
+    inputs:
+      - input
+    expectations:
+      - output_in_order_1
+      - output_in_order_2


### PR DESCRIPTION
fixes: https://github.com/creek-service/creek-kafka/issues/151

Also added an option extension to allow the user control of this.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended