### PR TITLE
Remove `throws IOException`

### DIFF
--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/KafkaClientsExtension.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/KafkaClientsExtension.java
@@ -18,7 +18,6 @@ package org.creekservice.api.kafka.extension;
 
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.time.Duration;
 import java.util.Properties;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -107,11 +106,10 @@ public interface KafkaClientsExtension extends CreekExtension, Closeable {
      * consumers}, waiting for up to the supplier {@code timeout} for <i>each</i> to close.
      *
      * @param timeout The maximum time to wait for producer to complete any pending requests.
-     * @throws IOException see Kafka clients for details
      * @see org.apache.kafka.clients.producer.KafkaProducer#close(Duration)
      * @see org.apache.kafka.clients.consumer.KafkaConsumer#close(Duration)
      */
-    void close(Duration timeout) throws IOException;
+    void close(Duration timeout);
 
     /**
      * Close the resources associated with the extension.
@@ -119,11 +117,10 @@ public interface KafkaClientsExtension extends CreekExtension, Closeable {
      * <p>Closes all shared {@link #producer(String) producers} and {@link #consumer(String)}
      * consumers}, waiting until all previously sent requests complete.
      *
-     * @throws IOException see Kafka clients for details
      * @see org.apache.kafka.clients.producer.KafkaProducer#close(Duration)
      * @see org.apache.kafka.clients.consumer.KafkaConsumer#close(Duration)
      */
-    default void close() throws IOException {
+    default void close() {
         close(Duration.ofMillis(Long.MAX_VALUE));
     }
 }

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/ClientsExtension.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/ClientsExtension.java
@@ -18,7 +18,6 @@ package org.creekservice.internal.kafka.extension;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
@@ -92,7 +91,7 @@ public final class ClientsExtension implements KafkaClientsExtension {
     }
 
     @Override
-    public void close(final Duration timeout) throws IOException {
+    public void close(final Duration timeout) {
         for (final Producer<byte[], byte[]> producer : producers.values()) {
             producer.close(timeout);
         }

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsExtension.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsExtension.java
@@ -18,7 +18,6 @@ package org.creekservice.internal.kafka.streams.extension;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.Properties;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -79,7 +78,7 @@ public final class StreamsExtension implements KafkaStreamsExtension {
     }
 
     @Override
-    public void close(final Duration timeout) throws IOException {
+    public void close(final Duration timeout) {
         clientsExtension.close(timeout);
     }
 

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsExtensionTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsExtensionTest.java
@@ -121,7 +121,7 @@ class StreamsExtensionTest {
     }
 
     @Test
-    void shouldCloseClientExtOnClose() throws Exception {
+    void shouldCloseClientExtOnClose() {
         // Given:
         final Duration duration = Duration.ofMillis(1535);
 

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/TearDownTestListenerTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/TearDownTestListenerTest.java
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
-import java.io.IOException;
 import java.time.Duration;
 import org.creekservice.internal.kafka.extension.ClientsExtension;
 import org.junit.jupiter.api.BeforeEach;

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/TearDownTestListenerTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/TearDownTestListenerTest.java
@@ -41,7 +41,7 @@ class TearDownTestListenerTest {
     }
 
     @Test
-    void shouldCloseAfterSuite() throws Exception {
+    void shouldCloseAfterSuite() {
         // When:
         listener.afterSuite(null, null);
 
@@ -50,9 +50,9 @@ class TearDownTestListenerTest {
     }
 
     @Test
-    void shouldSwallowExceptions() throws Exception {
+    void shouldSwallowExceptions() {
         // Given:
-        doThrow(new IOException("boom")).when(clientsExt).close(any());
+        doThrow(new RuntimeException("boom")).when(clientsExt).close(any());
 
         // When:
         listener.afterSuite(null, null);


### PR DESCRIPTION
...not sure why it's there as even old Kafka client versions don't seem to throw this checked exception...

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended