### PR TITLE
Set Kafka startup and shutdown timeouts

### DIFF
--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDef.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDef.java
@@ -19,6 +19,7 @@ package org.creekservice.internal.kafka.streams.test.extension.testsuite;
 import static java.lang.System.lineSeparator;
 import static org.creekservice.api.base.type.Preconditions.requireNonBlank;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -34,6 +35,8 @@ final class KafkaContainerDef implements ServiceDefinition {
     private static final int ZOOKEEPER_PORT = 2181;
     private static final String DEFAULT_INTERNAL_PARTITION_COUNT = "1";
     private static final String DEFAULT_INTERNAL_TOPIC_RF = "1";
+    private static final Duration STARTUP_TIMEOUT = Duration.ofSeconds(90);
+    private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(1);
 
     private final String name;
     private final String kafkaDockerImage;
@@ -61,6 +64,8 @@ final class KafkaContainerDef implements ServiceDefinition {
         commandLines.addAll(setUpKafka(instance));
 
         instance.setCommand("sh", "-c", String.join(lineSeparator(), commandLines));
+        instance.setStartupTimeout(STARTUP_TIMEOUT);
+        instance.setShutdownTimeout(SHUTDOWN_TIMEOUT);
     }
 
     @Override

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDefTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDefTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.testing.EqualsTester;
+import java.time.Duration;
 import java.util.List;
 import org.creekservice.api.system.test.extension.test.env.suite.service.ConfigurableServiceInstance;
 import org.creekservice.api.system.test.extension.test.env.suite.service.ServiceInstance.ExecResult;
@@ -194,6 +195,24 @@ class KafkaContainerDefTest {
 
         // Then:
         verify(instance).addExposedPorts(9093);
+    }
+
+    @Test
+    void shouldSetLongerStartUpTimeoutAsKafkaCanTakeAWhile() {
+        // When:
+        def.configureInstance(instance);
+
+        // Then:
+        verify(instance).setStartupTimeout(Duration.ofSeconds(90));
+    }
+
+    @Test
+    void shouldConfigureQuickShutdownTimeoutToKeepTestsSpeedy() {
+        // When:
+        def.configureInstance(instance);
+
+        // Then:
+        verify(instance).setShutdownTimeout(Duration.ofSeconds(1));
     }
 
     @Test


### PR DESCRIPTION
Increase the Kafka container startup timeout, (30 -> 90 seconds), as Kafka can take a while to startup.

Decrease the Kafka container shutdown timeout, (30 -> 1 seconds), as Kafka can take a while to stop, and a graceful stop is not required. Reducing this speeds up tests.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure correct labels applied
- [ ] Ensure any appropriate documentation has been added or amended