### PR TITLE
Prep work for registering schemas

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
         run: |
           ./gradlew -Dgradle.publish.key="$GRADLE_PUBLISH_KEY" -Dgradle.publish.secret="$GRADLE_PUBLISH_SECRET" publishPlugins
 
+  # Until Creek fully supports Windows, minimal check:
   build_windows:
     runs-on: windows-latest
     steps:

--- a/client-extension/src/main/java/module-info.java
+++ b/client-extension/src/main/java/module-info.java
@@ -30,6 +30,7 @@ module creek.kafka.clients.extension {
     exports org.creekservice.api.kafka.extension;
     exports org.creekservice.api.kafka.extension.client;
     exports org.creekservice.api.kafka.extension.config;
+    exports org.creekservice.api.kafka.extension.logging;
     exports org.creekservice.api.kafka.extension.resource;
     exports org.creekservice.internal.kafka.extension to
             creek.kafka.streams.extension,

--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/KafkaClientsExtensionProvider.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/KafkaClientsExtensionProvider.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import org.creekservice.api.base.annotation.VisibleForTesting;
 import org.creekservice.api.kafka.extension.client.TopicClient;
 import org.creekservice.api.kafka.extension.config.ClustersProperties;
+import org.creekservice.api.kafka.serde.provider.KafkaSerdeProviders;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
 import org.creekservice.api.service.extension.CreekExtensionProvider;
 import org.creekservice.api.service.extension.CreekService;
@@ -47,12 +48,16 @@ public final class KafkaClientsExtensionProvider
 
     /** Constructor */
     public KafkaClientsExtensionProvider() {
+        this(KafkaSerdeProviders.create());
+    }
+
+    private KafkaClientsExtensionProvider(final KafkaSerdeProviders serdeProviders) {
         this(
                 new KafkaResourceValidator(),
                 new ClustersPropertiesFactory(),
-                KafkaTopicClient::new,
+                props -> new KafkaTopicClient(props, serdeProviders),
                 ClientsExtension::new,
-                new ResourceRegistryFactory());
+                new ResourceRegistryFactory(serdeProviders));
     }
 
     @VisibleForTesting

--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/logging/LoggingField.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/logging/LoggingField.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.kafka.extension.logging;
+
+/** Common logging fields. */
+public enum LoggingField {
+    partitions,
+    topicIds,
+    topicId
+}

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistryFactory.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistryFactory.java
@@ -29,9 +29,8 @@ import org.creekservice.api.kafka.extension.config.ClustersProperties;
 import org.creekservice.api.kafka.extension.logging.LoggingField;
 import org.creekservice.api.kafka.metadata.CreatableKafkaTopic;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
-import org.creekservice.api.kafka.metadata.SerializationFormat;
+import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.PartDescriptor;
 import org.creekservice.api.kafka.serde.provider.KafkaSerdeProvider;
-import org.creekservice.api.kafka.serde.provider.KafkaSerdeProvider.TopicPart;
 import org.creekservice.api.kafka.serde.provider.KafkaSerdeProviders;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
 import org.creekservice.internal.kafka.extension.resource.TopicCollector.CollectedTopics;
@@ -103,31 +102,25 @@ public final class ResourceRegistryFactory {
     private <K, V> Topic<K, V> createTopicResource(
             final KafkaTopicDescriptor<K, V> def, final ClustersProperties allProperties) {
         final Map<String, Object> properties = allProperties.get(def.cluster());
-        final Serde<K> keySerde = serde(def.key(), def.id(), TopicPart.key, properties);
-        final Serde<V> valueSerde = serde(def.value(), def.id(), TopicPart.value, properties);
+        final Serde<K> keySerde = serde(def.key(), properties);
+        final Serde<V> valueSerde = serde(def.value(), properties);
         return topicFactory.create(def, keySerde, valueSerde);
     }
 
     private <T> Serde<T> serde(
-            final KafkaTopicDescriptor.PartDescriptor<T> part,
-            final URI topicId,
-            final TopicPart topicPart,
-            final Map<String, Object> clusterProperties) {
-        final KafkaSerdeProvider provider = provider(part, topicId, topicPart);
+            final PartDescriptor<T> part, final Map<String, Object> clusterProperties) {
+        final KafkaSerdeProvider provider = provider(part);
 
         final Serde<T> serde = provider.create(part);
-        serde.configure(clusterProperties, topicPart.equals(TopicPart.key));
+        serde.configure(clusterProperties, part.part().isKey());
         return serde;
     }
 
-    private <T> KafkaSerdeProvider provider(
-            final KafkaTopicDescriptor.PartDescriptor<T> part,
-            final URI topicId,
-            final TopicPart topicPart) {
+    private <T> KafkaSerdeProvider provider(final PartDescriptor<T> part) {
         try {
             return serdeProviders.get(part.format());
         } catch (final Exception e) {
-            throw new UnknownSerializationFormatException(part.format(), topicId, topicPart, e);
+            throw new UnknownSerializationFormatException(part, e);
         }
     }
 
@@ -143,21 +136,17 @@ public final class ResourceRegistryFactory {
     }
 
     private static final class UnknownSerializationFormatException extends RuntimeException {
-        UnknownSerializationFormatException(
-                final SerializationFormat format,
-                final URI topicId,
-                final TopicPart topicPart,
-                final Throwable cause) {
+        UnknownSerializationFormatException(final PartDescriptor<?> part, final Throwable cause) {
             super(
                     "Unknown "
-                            + topicPart
+                            + part.part()
                             + " serialization format encountered."
                             + " format="
-                            + format
+                            + part.format()
                             + ", "
                             + LoggingField.topicId
                             + "="
-                            + topicId,
+                            + part.topic().id(),
                     cause);
         }
     }

--- a/client-extension/src/test/java/org/creekservice/api/kafka/extension/KafkaClientsExtensionProviderTest.java
+++ b/client-extension/src/test/java/org/creekservice/api/kafka/extension/KafkaClientsExtensionProviderTest.java
@@ -59,6 +59,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 
+@SuppressWarnings("resource")
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class KafkaClientsExtensionProviderTest {

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/ClientExtensionFunctionalTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/ClientExtensionFunctionalTest.java
@@ -43,6 +43,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.creekservice.api.kafka.extension.config.ClustersProperties;
 import org.creekservice.api.kafka.extension.resource.KafkaTopic;
 import org.creekservice.api.kafka.metadata.CreatableKafkaTopic;
+import org.creekservice.api.kafka.serde.provider.KafkaSerdeProviders;
 import org.creekservice.api.kafka.test.service.TestServiceDescriptor;
 import org.creekservice.api.kafka.test.service.UpstreamAggregateDescriptor;
 import org.creekservice.internal.kafka.extension.resource.ResourceRegistry;
@@ -83,7 +84,7 @@ class ClientExtensionFunctionalTest {
                         .build(Set.of());
 
         final ResourceRegistry registry =
-                new ResourceRegistryFactory()
+                new ResourceRegistryFactory(KafkaSerdeProviders.create())
                         .create(List.of(new TestServiceDescriptor()), clustersProperties);
 
         try (Admin admin = Admin.create(clustersProperties.get(DEFAULT_CLUSTER_NAME))) {

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClientFunctionalTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClientFunctionalTest.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.creekservice.api.kafka.extension.config.ClustersProperties;
 import org.creekservice.api.kafka.metadata.CreatableKafkaTopic;
 import org.creekservice.api.kafka.metadata.OwnedKafkaTopicOutput;
+import org.creekservice.api.kafka.serde.provider.KafkaSerdeProviders;
 import org.creekservice.test.TopicConfigBuilder;
 import org.creekservice.test.TopicDescriptors;
 import org.hamcrest.Description;
@@ -97,7 +98,7 @@ class KafkaTopicClientFunctionalTest {
 
     @BeforeEach
     void setUp() {
-        client = new KafkaTopicClient(clustersProperties);
+        client = new KafkaTopicClient(clustersProperties, KafkaSerdeProviders.create());
 
         final Map<String, Object> defaultClusterProps =
                 Map.of(BOOTSTRAP_SERVERS_CONFIG, DEFAULT_CLUSTER.getBootstrapServers());

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClientTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClientTest.java
@@ -41,7 +41,6 @@ import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.creekservice.api.kafka.extension.config.ClustersProperties;
 import org.creekservice.api.kafka.metadata.CreatableKafkaTopic;
 import org.creekservice.api.kafka.serde.provider.KafkaSerdeProvider;
-import org.creekservice.api.kafka.serde.provider.KafkaSerdeProvider.TopicPart;
 import org.creekservice.api.kafka.serde.provider.KafkaSerdeProviders;
 import org.creekservice.api.test.observability.logging.structured.TestStructuredLogger;
 import org.creekservice.test.TopicDescriptors;
@@ -222,8 +221,7 @@ class KafkaTopicClientTest {
         client.ensure(List.of(TOPIC_A));
 
         // Then:
-        verify(kafkaSerdeProvider)
-                .ensureTopicPartResources(TOPIC_A.key(), TopicPart.key, TOPIC_A, A_CLUSTER_PROPS);
+        verify(kafkaSerdeProvider).ensureTopicPartResources(TOPIC_A.key(), A_CLUSTER_PROPS);
     }
 
     @Test
@@ -232,9 +230,7 @@ class KafkaTopicClientTest {
         client.ensure(List.of(TOPIC_A));
 
         // Then:
-        verify(otherSerdeProvider)
-                .ensureTopicPartResources(
-                        TOPIC_A.value(), TopicPart.value, TOPIC_A, A_CLUSTER_PROPS);
+        verify(otherSerdeProvider).ensureTopicPartResources(TOPIC_A.value(), A_CLUSTER_PROPS);
     }
 
     @Test

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/KafkaTopicDescriptorsTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/KafkaTopicDescriptorsTest.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import org.creekservice.api.kafka.metadata.CreatableKafkaTopic;
 import org.creekservice.api.kafka.metadata.KafkaTopicConfig;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
+import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.PartDescriptor.Part;
 import org.creekservice.api.kafka.metadata.OwnedKafkaTopicOutput;
 import org.creekservice.api.kafka.metadata.SerializationFormat;
 import org.junit.jupiter.api.Test;
@@ -565,8 +566,8 @@ class KafkaTopicDescriptorsTest {
                 final Class<V> valueType) {
             this.name = name;
             this.cluster = cluster;
-            this.key = new TestPart<>(keyType, keyFormat);
-            this.value = new TestPart<>(valueType, valueFormat);
+            this.key = new TestPart<>(Part.key, keyType, keyFormat);
+            this.value = new TestPart<>(Part.value, valueType, valueFormat);
         }
 
         @Override
@@ -589,13 +590,20 @@ class KafkaTopicDescriptorsTest {
             return value;
         }
 
-        private static final class TestPart<T> implements PartDescriptor<T> {
+        private final class TestPart<T> implements PartDescriptor<T> {
+            private final Part part;
             private final Class<T> type;
             private final SerializationFormat format;
 
-            TestPart(final Class<T> type, final SerializationFormat format) {
+            TestPart(final Part part, final Class<T> type, final SerializationFormat format) {
+                this.part = part;
                 this.type = type;
                 this.format = format;
+            }
+
+            @Override
+            public Part part() {
+                return part;
             }
 
             @Override
@@ -606,6 +614,11 @@ class KafkaTopicDescriptorsTest {
             @Override
             public Class<T> type() {
                 return type;
+            }
+
+            @Override
+            public KafkaTopicDescriptor<?, ?> topic() {
+                return FirstKafkaTopic.this;
             }
         }
     }
@@ -626,8 +639,8 @@ class KafkaTopicDescriptorsTest {
                 final Class<V> valueType) {
             this.name = name;
             this.cluster = cluster;
-            this.key = new TestPart<>(keyType, keyFormat);
-            this.value = new TestPart<>(valueType, valueFormat);
+            this.key = new TestPart<>(Part.key, keyType, keyFormat);
+            this.value = new TestPart<>(Part.value, valueType, valueFormat);
         }
 
         @Override
@@ -650,13 +663,20 @@ class KafkaTopicDescriptorsTest {
             return value;
         }
 
-        private static final class TestPart<T> implements PartDescriptor<T> {
+        private final class TestPart<T> implements PartDescriptor<T> {
+            private final Part part;
             private final Class<T> type;
             private final SerializationFormat format;
 
-            TestPart(final Class<T> type, final SerializationFormat format) {
+            TestPart(final Part part, final Class<T> type, final SerializationFormat format) {
+                this.part = part;
                 this.type = type;
                 this.format = format;
+            }
+
+            @Override
+            public Part part() {
+                return part;
             }
 
             @Override
@@ -667,6 +687,11 @@ class KafkaTopicDescriptorsTest {
             @Override
             public Class<T> type() {
                 return type;
+            }
+
+            @Override
+            public KafkaTopicDescriptor<?, ?> topic() {
+                return SecondKafkaTopic.this;
             }
         }
     }
@@ -689,8 +714,8 @@ class KafkaTopicDescriptorsTest {
                 final KafkaTopicConfig config) {
             this.name = name;
             this.cluster = cluster;
-            this.key = new TestPart<>(keyType, keyFormat);
-            this.value = new TestPart<>(valueType, valueFormat);
+            this.key = new TestPart<>(Part.key, keyType, keyFormat);
+            this.value = new TestPart<>(Part.value, valueType, valueFormat);
             this.config = config;
         }
 
@@ -719,13 +744,20 @@ class KafkaTopicDescriptorsTest {
             return config;
         }
 
-        private static final class TestPart<T> implements PartDescriptor<T> {
+        private final class TestPart<T> implements PartDescriptor<T> {
+            private final Part part;
             private final Class<T> type;
             private final SerializationFormat format;
 
-            TestPart(final Class<T> type, final SerializationFormat format) {
+            TestPart(final Part part, final Class<T> type, final SerializationFormat format) {
+                this.part = part;
                 this.type = type;
                 this.format = format;
+            }
+
+            @Override
+            public Part part() {
+                return part;
             }
 
             @Override
@@ -736,6 +768,11 @@ class KafkaTopicDescriptorsTest {
             @Override
             public Class<T> type() {
                 return type;
+            }
+
+            @Override
+            public KafkaTopicDescriptor<?, ?> topic() {
+                return FirstCreatableKafkaTopic.this;
             }
         }
     }
@@ -760,8 +797,8 @@ class KafkaTopicDescriptorsTest {
                 final KafkaTopicConfig config) {
             this.name = name;
             this.cluster = cluster;
-            this.key = new TestPart<>(keyType, keyFormat);
-            this.value = new TestPart<>(valueType, valueFormat);
+            this.key = new TestPart<>(Part.key, keyType, keyFormat);
+            this.value = new TestPart<>(Part.value, valueType, valueFormat);
             this.config = config;
         }
 
@@ -790,13 +827,20 @@ class KafkaTopicDescriptorsTest {
             return config;
         }
 
-        private static final class TestPart<T> implements PartDescriptor<T> {
+        private final class TestPart<T> implements PartDescriptor<T> {
+            private final Part part;
             private final Class<T> type;
             private final SerializationFormat format;
 
-            TestPart(final Class<T> type, final SerializationFormat format) {
+            TestPart(final Part part, final Class<T> type, final SerializationFormat format) {
+                this.part = part;
                 this.type = type;
                 this.format = format;
+            }
+
+            @Override
+            public Part part() {
+                return part;
             }
 
             @Override
@@ -807,6 +851,11 @@ class KafkaTopicDescriptorsTest {
             @Override
             public Class<T> type() {
                 return type;
+            }
+
+            @Override
+            public KafkaTopicDescriptor<?, ?> topic() {
+                return SecondCreatableKafkaTopic.this;
             }
         }
     }

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistryFactoryTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistryFactoryTest.java
@@ -16,6 +16,7 @@
 
 package org.creekservice.internal.kafka.extension.resource;
 
+import static org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.PartDescriptor.Part;
 import static org.creekservice.api.kafka.metadata.SerializationFormat.serializationFormat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -102,11 +103,11 @@ class ResourceRegistryFactoryTest {
         when(keySerdeProvider.create(any())).thenReturn((Serde) keySerde);
         when(valueSerdeProvider.create(any())).thenReturn((Serde) valueSerde);
 
-        setUpPart(aKeyPart, String.class, KEY_FORMAT);
-        setUpPart(bKeyPart, String.class, KEY_FORMAT);
-        setUpPart(aValuePart, long.class, VALUE_FORMAT);
-        setUpPart(bValuePart, long.class, VALUE_FORMAT);
-        setUpPart(customPart, long.class, VALUE_FORMAT);
+        setUpPart(aKeyPart, Part.key, topicDefA, String.class, KEY_FORMAT);
+        setUpPart(bKeyPart, Part.key, topicDefB, String.class, KEY_FORMAT);
+        setUpPart(aValuePart, Part.value, topicDefA, long.class, VALUE_FORMAT);
+        setUpPart(bValuePart, Part.value, topicDefB, long.class, VALUE_FORMAT);
+        setUpPart(customPart, Part.value, topicDefB, long.class, VALUE_FORMAT);
 
         setUpTopic(topicDefA, "a", aKeyPart, aValuePart);
         setUpTopic(topicDefB, "b", bKeyPart, bValuePart);
@@ -298,12 +299,17 @@ class ResourceRegistryFactoryTest {
         assertThat(e.getCause(), is(cause));
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private <T> void setUpPart(
-            final PartDescriptor<T> part,
+            final PartDescriptor<T> descriptor,
+            final Part part,
+            final KafkaTopicDescriptor<?, ?> topic,
             final Class<T> keyType,
             final SerializationFormat format) {
-        when(part.type()).thenReturn(keyType);
-        when(part.format()).thenReturn(format);
+        when(descriptor.part()).thenReturn(part);
+        when(descriptor.type()).thenReturn(keyType);
+        when(descriptor.format()).thenReturn(format);
+        when(descriptor.topic()).thenReturn((KafkaTopicDescriptor) topic);
     }
 
     private <K, V> void setUpTopic(

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistryFactoryTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistryFactoryTest.java
@@ -50,6 +50,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+@SuppressWarnings("resource")
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
@@ -268,7 +269,9 @@ class ResourceRegistryFactoryTest {
         // Then:
         assertThat(
                 e.getMessage(),
-                is("Unknown key serialization format encountered. format=key-format, topic=a"));
+                is(
+                        "Unknown key serialization format encountered. format=key-format,"
+                                + " topicId=kafka-topic://c/a"));
 
         assertThat(e.getCause(), is(cause));
     }
@@ -288,7 +291,9 @@ class ResourceRegistryFactoryTest {
         // Then:
         assertThat(
                 e.getMessage(),
-                is("Unknown value serialization format encountered. format=value-format, topic=a"));
+                is(
+                        "Unknown value serialization format encountered. format=value-format,"
+                                + " topicId=kafka-topic://c/a"));
 
         assertThat(e.getCause(), is(cause));
     }
@@ -306,6 +311,7 @@ class ResourceRegistryFactoryTest {
             final String name,
             final PartDescriptor<K> keyPart,
             final PartDescriptor<V> valuePart) {
+        when(topic.id()).thenReturn(KafkaTopicDescriptor.resourceId("c", name));
         when(topic.name()).thenReturn(name);
         when(topic.cluster()).thenReturn(CLUSTER_NAME);
         when(topic.key()).thenReturn(keyPart);

--- a/docs-examples/build.gradle.kts
+++ b/docs-examples/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
 // begin-snippet: deps
 dependencies {
 // end-snippet
-
+    implementation("log4j:log4j:1.2.17")
 // begin-snippet: meta
     implementation("org.creekservice:creek-kafka-metadata:0.4.1")
 // end-snippet

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/KafkaTopicDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/KafkaTopicDescriptor.java
@@ -69,6 +69,21 @@ public interface KafkaTopicDescriptor<K, V> extends ResourceDescriptor {
 
     /** Descriptor for part of a topic's record. */
     interface PartDescriptor<T> {
+
+        enum Part {
+            key,
+            value;
+
+            public boolean isKey() {
+                return this == key;
+            }
+        }
+
+        /**
+         * @return which {@code Part} this descriptor is for.
+         */
+        Part part();
+
         /**
          * The serialization format used to serialize this part of the record.
          *
@@ -86,6 +101,11 @@ public interface KafkaTopicDescriptor<K, V> extends ResourceDescriptor {
          * @return The part's java type.
          */
         Class<T> type();
+
+        /**
+         * @return the topic this instance is part of.
+         */
+        KafkaTopicDescriptor<?, ?> topic();
     }
 
     /**

--- a/metadata/src/test/java/org/creekservice/api/kafka/metadata/KafkaTopicDescriptorTest.java
+++ b/metadata/src/test/java/org/creekservice/api/kafka/metadata/KafkaTopicDescriptorTest.java
@@ -20,7 +20,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
@@ -57,6 +59,12 @@ class KafkaTopicDescriptorTest {
         // Then:
         assertThat(e.getCause(), instanceOf(URISyntaxException.class));
         assertThat(e.getMessage(), containsString("Malformed escape pair"));
+    }
+
+    @Test
+    void shouldKnowIfPartIsKeyPart() {
+        assertTrue(KafkaTopicDescriptor.PartDescriptor.Part.key.isKey());
+        assertFalse(KafkaTopicDescriptor.PartDescriptor.Part.value.isKey());
     }
 
     private KafkaTopicDescriptor<Void, Void> descriptor(final String cluster, final String name) {

--- a/serde/src/main/java/org/creekservice/api/kafka/serde/provider/KafkaSerdeProvider.java
+++ b/serde/src/main/java/org/creekservice/api/kafka/serde/provider/KafkaSerdeProvider.java
@@ -18,7 +18,6 @@ package org.creekservice.api.kafka.serde.provider;
 
 import java.util.Map;
 import org.apache.kafka.common.serialization.Serde;
-import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.PartDescriptor;
 import org.creekservice.api.kafka.metadata.SerializationFormat;
 
@@ -32,11 +31,6 @@ import org.creekservice.api.kafka.metadata.SerializationFormat;
  * META-INFO.services} directory.
  */
 public interface KafkaSerdeProvider {
-
-    enum TopicPart {
-        key,
-        value
-    }
 
     /**
      * @return the <i>unique</i> serialization format the serde provides.
@@ -52,15 +46,10 @@ public interface KafkaSerdeProvider {
      * {@code topicPart}.
      *
      * @param part the descriptor for the topic part.
-     * @param topicPart Identifies if {@code part} is a key or value part.
-     * @param topic the topic the {@code part} belongs to.
      * @param clusterProperties the properties of the cluster the {@code topic} belongs to.
      */
     default void ensureTopicPartResources(
-            PartDescriptor<?> part,
-            TopicPart topicPart,
-            KafkaTopicDescriptor<?, ?> topic,
-            Map<String, Object> clusterProperties) {}
+            PartDescriptor<?> part, Map<String, Object> clusterProperties) {}
 
     /**
      * Get the serde for the supplied Kafka topic {@code part}.

--- a/serde/src/main/java/org/creekservice/api/kafka/serde/provider/KafkaSerdeProvider.java
+++ b/serde/src/main/java/org/creekservice/api/kafka/serde/provider/KafkaSerdeProvider.java
@@ -16,8 +16,10 @@
 
 package org.creekservice.api.kafka.serde.provider;
 
+import java.util.Map;
 import org.apache.kafka.common.serialization.Serde;
 import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
+import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.PartDescriptor;
 import org.creekservice.api.kafka.metadata.SerializationFormat;
 
 // begin-snippet: kafka-serde-provider
@@ -31,20 +33,44 @@ import org.creekservice.api.kafka.metadata.SerializationFormat;
  */
 public interface KafkaSerdeProvider {
 
+    enum TopicPart {
+        key,
+        value
+    }
+
     /**
      * @return the <i>unique</i> serialization format the serde provides.
      */
     SerializationFormat format();
 
     /**
-     * Get the serde for the supplied Kafka record {@code part}.
+     * Ensure any resources associated with a topic part are registered, e.g. schemas registered in
+     * the appropriate schema store.
+     *
+     * <p>The method allows serde providers to optionally create / register resources associated
+     * with a topic's key or value. Implementations should only ensure resources for the supplied
+     * {@code topicPart}.
+     *
+     * @param part the descriptor for the topic part.
+     * @param topicPart Identifies if {@code part} is a key or value part.
+     * @param topic the topic the {@code part} belongs to.
+     * @param clusterProperties the properties of the cluster the {@code topic} belongs to.
+     */
+    default void ensureTopicPartResources(
+            PartDescriptor<?> part,
+            TopicPart topicPart,
+            KafkaTopicDescriptor<?, ?> topic,
+            Map<String, Object> clusterProperties) {}
+
+    /**
+     * Get the serde for the supplied Kafka topic {@code part}.
      *
      * <p>{@link Serde#configure} will be called on the returned serde.
      *
-     * @param part the part descriptor
      * @param <T> the type of the part.
+     * @param part the descriptor for the topic part.
      * @return the serde to use to serialize and deserialize the part.
      */
-    <T> Serde<T> create(KafkaTopicDescriptor.PartDescriptor<T> part);
+    <T> Serde<T> create(PartDescriptor<T> part);
 }
 // end-snippet

--- a/serde/src/main/java/org/creekservice/api/kafka/serde/provider/NativeKafkaSerde.java
+++ b/serde/src/main/java/org/creekservice/api/kafka/serde/provider/NativeKafkaSerde.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.kafka.serde.provider;
+
+import org.creekservice.internal.kafka.serde.provider.NativeKafkaSerdeProvider;
+
+/** Utility class to access details on the types the {@link NativeKafkaSerdeProvider} supports. */
+public final class NativeKafkaSerde {
+
+    private NativeKafkaSerde() {}
+
+    /**
+     * Check if this provider supports the supplied {@code type}.
+     *
+     * @param type the type to check
+     * @return {@code true} if supported, {@code false} otherwise.
+     */
+    public static boolean supports(final Class<?> type) {
+        return NativeKafkaSerdeProvider.supports(type);
+    }
+}

--- a/serde/src/main/java/org/creekservice/internal/kafka/serde/provider/NativeKafkaSerdeProvider.java
+++ b/serde/src/main/java/org/creekservice/internal/kafka/serde/provider/NativeKafkaSerdeProvider.java
@@ -69,6 +69,16 @@ public final class NativeKafkaSerdeProvider implements KafkaSerdeProvider {
         return (Serde<T>) supplier.get();
     }
 
+    /**
+     * Check if this provider supports the supplied {@code type}.
+     *
+     * @param type the type to check
+     * @return {@code true} if supported, {@code false} otherwise.
+     */
+    public static boolean supports(final Class<?> type) {
+        return SUPPLIERS.containsKey(type);
+    }
+
     private static final class UnsupportedTypeException extends IllegalArgumentException {
         <T> UnsupportedTypeException(final Class<T> type) {
             super("The supplied type is not supported by the kafka format: " + type.getName());

--- a/serde/src/test/java/org/creekservice/api/kafka/serde/provider/NativeKafkaSerdeTest.java
+++ b/serde/src/test/java/org/creekservice/api/kafka/serde/provider/NativeKafkaSerdeTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.kafka.serde.provider;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class NativeKafkaSerdeTest {
+
+    @Test
+    void shouldSupportInt() {
+        assertTrue(NativeKafkaSerde.supports(Integer.class));
+    }
+
+    @Test
+    void shouldNotSupportComplexTypes() {
+        assertFalse(NativeKafkaSerde.supports(Object.class));
+    }
+}

--- a/streams-test/src/test/java/org/creekservice/internal/kafka/streams/test/util/TopicDescriptors.java
+++ b/streams-test/src/test/java/org/creekservice/internal/kafka/streams/test/util/TopicDescriptors.java
@@ -25,7 +25,8 @@ import java.net.URI;
 import java.util.Optional;
 import org.creekservice.api.kafka.metadata.CreatableKafkaTopicInternal;
 import org.creekservice.api.kafka.metadata.KafkaTopicConfig;
-import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.PartDescriptor;
+import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
+import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.PartDescriptor.Part;
 import org.creekservice.api.kafka.metadata.KafkaTopicInput;
 import org.creekservice.api.kafka.metadata.KafkaTopicInternal;
 import org.creekservice.api.kafka.metadata.KafkaTopicOutput;
@@ -241,27 +242,8 @@ public final class TopicDescriptors {
         return new OutputTopicDescriptor<>(clusterName, topicName, keyType, valueType, config);
     }
 
-    private static final class KafkaPart<T> implements PartDescriptor<T> {
-
-        private final Class<T> type;
-
-        KafkaPart(final Class<T> type) {
-            this.type = requireNonNull(type, "type");
-        }
-
-        @Override
-        public SerializationFormat format() {
-            return KAFKA_FORMAT;
-        }
-
-        @Override
-        public Class<T> type() {
-            return type;
-        }
-    }
-
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private abstract static class TopicDescriptor<K, V> {
+    private abstract static class TopicDescriptor<K, V> implements KafkaTopicDescriptor<K, V> {
         private final String topicName;
         private final PartDescriptor<K> key;
         private final PartDescriptor<V> value;
@@ -274,25 +256,59 @@ public final class TopicDescriptors {
                 final Class<V> valueType,
                 final Optional<TopicConfigBuilder> config) {
             this.topicName = requireNonBlank(topicName, "topicName");
-            this.key = new KafkaPart<>(keyType);
-            this.value = new KafkaPart<>(valueType);
+            this.key = new KafkaPart<>(Part.key, keyType);
+            this.value = new KafkaPart<>(Part.value, valueType);
             this.config = requireNonNull(config, "config").map(TopicConfigBuilder::build);
         }
 
+        @Override
         public String name() {
             return topicName;
         }
 
+        @Override
         public PartDescriptor<K> key() {
             return key;
         }
 
+        @Override
         public PartDescriptor<V> value() {
             return value;
         }
 
         public KafkaTopicConfig config() {
             return config.orElseThrow();
+        }
+
+        private final class KafkaPart<T> implements PartDescriptor<T> {
+
+            private final Part part;
+            private final Class<T> type;
+
+            KafkaPart(final Part part, final Class<T> type) {
+                this.part = requireNonNull(part, "part");
+                this.type = requireNonNull(type, "type");
+            }
+
+            @Override
+            public Part part() {
+                return part;
+            }
+
+            @Override
+            public SerializationFormat format() {
+                return KAFKA_FORMAT;
+            }
+
+            @Override
+            public Class<T> type() {
+                return type;
+            }
+
+            @Override
+            public KafkaTopicDescriptor<?, ?> topic() {
+                return TopicDescriptor.this;
+            }
         }
     }
 

--- a/test-service/src/main/java/org/creekservice/internal/kafka/test/service/TopicDescriptors.java
+++ b/test-service/src/main/java/org/creekservice/internal/kafka/test/service/TopicDescriptors.java
@@ -25,7 +25,8 @@ import java.net.URI;
 import java.util.Optional;
 import org.creekservice.api.kafka.metadata.CreatableKafkaTopicInternal;
 import org.creekservice.api.kafka.metadata.KafkaTopicConfig;
-import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.PartDescriptor;
+import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor;
+import org.creekservice.api.kafka.metadata.KafkaTopicDescriptor.PartDescriptor.Part;
 import org.creekservice.api.kafka.metadata.KafkaTopicInput;
 import org.creekservice.api.kafka.metadata.KafkaTopicInternal;
 import org.creekservice.api.kafka.metadata.KafkaTopicOutput;
@@ -241,27 +242,8 @@ public final class TopicDescriptors {
         return new OutputTopicDescriptor<>(clusterName, topicName, keyType, valueType, config);
     }
 
-    private static final class KafkaPart<T> implements PartDescriptor<T> {
-
-        private final Class<T> type;
-
-        KafkaPart(final Class<T> type) {
-            this.type = requireNonNull(type, "type");
-        }
-
-        @Override
-        public SerializationFormat format() {
-            return KAFKA_FORMAT;
-        }
-
-        @Override
-        public Class<T> type() {
-            return type;
-        }
-    }
-
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private abstract static class TopicDescriptor<K, V> {
+    private abstract static class TopicDescriptor<K, V> implements KafkaTopicDescriptor<K, V> {
         private final String topicName;
         private final PartDescriptor<K> key;
         private final PartDescriptor<V> value;
@@ -274,25 +256,59 @@ public final class TopicDescriptors {
                 final Class<V> valueType,
                 final Optional<TopicConfigBuilder> config) {
             this.topicName = requireNonBlank(topicName, "topicName");
-            this.key = new KafkaPart<>(keyType);
-            this.value = new KafkaPart<>(valueType);
+            this.key = new KafkaPart<>(Part.key, keyType);
+            this.value = new KafkaPart<>(Part.value, valueType);
             this.config = requireNonNull(config, "config").map(TopicConfigBuilder::build);
         }
 
+        @Override
         public String name() {
             return topicName;
         }
 
+        @Override
         public PartDescriptor<K> key() {
             return key;
         }
 
+        @Override
         public PartDescriptor<V> value() {
             return value;
         }
 
         public KafkaTopicConfig config() {
             return config.orElseThrow();
+        }
+
+        private final class KafkaPart<T> implements PartDescriptor<T> {
+
+            private final Part part;
+            private final Class<T> type;
+
+            KafkaPart(final Part part, final Class<T> type) {
+                this.part = requireNonNull(part, "part");
+                this.type = requireNonNull(type, "type");
+            }
+
+            @Override
+            public Part part() {
+                return part;
+            }
+
+            @Override
+            public SerializationFormat format() {
+                return KAFKA_FORMAT;
+            }
+
+            @Override
+            public Class<T> type() {
+                return type;
+            }
+
+            @Override
+            public KafkaTopicDescriptor<?, ?> topic() {
+                return TopicDescriptor.this;
+            }
         }
     }
 


### PR DESCRIPTION
Wire in the ability for a serde provider to 'ensure' the schemas of owned topics are registered. This is called during service initialisation.

This will be used when JSON schema serde is added. (https://github.com/creek-service/creek-kafka/issues/25).
