### PR TITLE
Provide way for users to register subtypes

### DIFF
--- a/json-serde/README.md
+++ b/json-serde/README.md
@@ -3,3 +3,5 @@
 # Creek Kafka JSON Serde
 
 Module containing a Creek Kafka serde implementation that can be plugged in to Creek to provide JSON serde support.
+
+For more information, see the [docs site](https://www.creekservice.org/creek-kafka/#json-schema-format).

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/JsonSchemaSerdeProvider.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/JsonSchemaSerdeProvider.java
@@ -34,6 +34,7 @@ import org.creekservice.api.service.extension.CreekService;
 import org.creekservice.api.service.extension.component.model.ComponentModelContainer.HandlerTypeRef;
 import org.creekservice.internal.kafka.serde.json.logging.LoggingField;
 import org.creekservice.internal.kafka.serde.json.mapper.GenericMapper;
+import org.creekservice.internal.kafka.serde.json.mapper.GenericMapperFactory;
 import org.creekservice.internal.kafka.serde.json.schema.SchemaConvertor;
 import org.creekservice.internal.kafka.serde.json.schema.resource.JsonSchemaResourceHandler;
 import org.creekservice.internal.kafka.serde.json.schema.serde.JsonSchemaSerde;
@@ -92,7 +93,7 @@ public class JsonSchemaSerdeProvider implements KafkaSerdeProvider {
         return new JsonSerdeFactory(
                 schemaStores,
                 SchemaFriendValidator::new,
-                GenericMapper::new,
+                new GenericMapperFactory(options.subTypes()),
                 JsonSchemaSerde::new,
                 StructuredLoggerFactory.internalLogger(JsonSchemaSerdeProvider.class));
     }
@@ -103,13 +104,13 @@ public class JsonSchemaSerdeProvider implements KafkaSerdeProvider {
         private final SrSchemaStores schemaStores;
         private final StructuredLogger logger;
         private final ValidatorFactory validatorFactory;
-        private final MapperFactory mapperFactory;
+        private final GenericMapperFactory mapperFactory;
         private final SerdeFactory jsonSchemaSerdeFactory;
 
         JsonSerdeFactory(
                 final SrSchemaStores schemaStores,
                 final ValidatorFactory validatorFactory,
-                final MapperFactory mapperFactory,
+                final GenericMapperFactory mapperFactory,
                 final SerdeFactory jsonSchemaSerdeFactory,
                 final StructuredLogger logger) {
             this.schemaStores = requireNonNull(schemaStores, "schemaStores");
@@ -166,11 +167,6 @@ public class JsonSchemaSerdeProvider implements KafkaSerdeProvider {
     @VisibleForTesting
     interface ValidatorFactory {
         SchemaValidator create(JsonSchema schema);
-    }
-
-    @VisibleForTesting
-    interface MapperFactory {
-        <T> GenericMapper<T> create(Class<T> type);
     }
 
     @VisibleForTesting

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/mapper/GenericMapper.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/mapper/GenericMapper.java
@@ -21,18 +21,12 @@ import static java.util.Objects.requireNonNull;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.util.Map;
-import org.creekservice.api.base.annotation.VisibleForTesting;
 
 public final class GenericMapper<T> implements JsonReader<T>, JsonWriter<T> {
 
     private final Class<T> type;
     private final JsonMapper mapper;
 
-    public GenericMapper(final Class<T> type) {
-        this(type, BaseJsonMapper.get());
-    }
-
-    @VisibleForTesting
     GenericMapper(final Class<T> type, final JsonMapper mapper) {
         this.type = requireNonNull(type, "type");
         this.mapper = requireNonNull(mapper, "mapper");

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/mapper/GenericMapperFactory.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/mapper/GenericMapperFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.serde.json.mapper;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import java.util.Map;
+import org.creekservice.api.base.annotation.VisibleForTesting;
+
+public final class GenericMapperFactory {
+
+    private final JsonMapper mapper;
+
+    public GenericMapperFactory(final Map<Class<?>, String> subTypes) {
+        this(subTypes, BaseJsonMapper.get());
+    }
+
+    @VisibleForTesting
+    GenericMapperFactory(final Map<Class<?>, String> subTypes, final JsonMapper jsonMapper) {
+        this.mapper = requireNonNull(jsonMapper, "jsonMapper");
+
+        subTypes.entrySet().stream()
+                .map(e -> new NamedType(e.getKey(), e.getValue()))
+                .forEach(jsonMapper::registerSubtypes);
+    }
+
+    public <T> GenericMapper<T> create(final Class<T> type) {
+        return new GenericMapper<>(type, mapper);
+    }
+}

--- a/json-serde/src/test/java/org/creekservice/api/kafka/serde/json/JsonSerdeExtensionOptionsTest.java
+++ b/json-serde/src/test/java/org/creekservice/api/kafka/serde/json/JsonSerdeExtensionOptionsTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.is;
 
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,12 @@ class JsonSerdeExtensionOptionsTest {
                 .addEqualityGroup(
                         JsonSerdeExtensionOptions.builder().build(),
                         JsonSerdeExtensionOptions.builder().build())
+                .addEqualityGroup(
+                        JsonSerdeExtensionOptions.builder().withSubtypes(String.class).build())
+                .addEqualityGroup(
+                        JsonSerdeExtensionOptions.builder()
+                                .withSubtype(String.class, "name")
+                                .build())
                 .addEqualityGroup(
                         JsonSerdeExtensionOptions.builder()
                                 .withTypeOverride(String.class, "diff")
@@ -68,5 +75,23 @@ class JsonSerdeExtensionOptionsTest {
 
         // Then:
         assertThat(builder.build().typeOverride(String.class), is(Optional.of("value")));
+    }
+
+    @Test
+    void shouldSupportNamedSubTypes() {
+        // When:
+        builder.withSubtype(String.class, "name");
+
+        // Then:
+        assertThat(builder.build().subTypes(), is(Map.of(String.class, "name")));
+    }
+
+    @Test
+    void shouldSupportUnnamedSubTypes() {
+        // When:
+        builder.withSubtypes(String.class, Integer.class);
+
+        // Then:
+        assertThat(builder.build().subTypes(), is(Map.of(String.class, "", Integer.class, "")));
     }
 }

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/JsonSchemaSerdeProviderTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/JsonSchemaSerdeProviderTest.java
@@ -47,6 +47,7 @@ import org.creekservice.api.service.extension.CreekService;
 import org.creekservice.api.service.extension.component.model.ComponentModelContainer.HandlerTypeRef;
 import org.creekservice.api.test.observability.logging.structured.TestStructuredLogger;
 import org.creekservice.internal.kafka.serde.json.mapper.GenericMapper;
+import org.creekservice.internal.kafka.serde.json.mapper.GenericMapperFactory;
 import org.creekservice.internal.kafka.serde.json.model.TestValueV0;
 import org.creekservice.internal.kafka.serde.json.schema.SchemaConvertor;
 import org.creekservice.internal.kafka.serde.json.schema.resource.JsonSchemaResourceHandler;
@@ -237,7 +238,7 @@ class JsonSchemaSerdeProviderTest {
 
         @Mock private RegisteredSchema<TestValueV0> registeredSchema;
         @Mock private JsonSchemaSerdeProvider.ValidatorFactory validatorFactory;
-        @Mock private JsonSchemaSerdeProvider.MapperFactory mapperFactory;
+        @Mock private GenericMapperFactory mapperFactory;
         @Mock private JsonSchemaSerdeProvider.SerdeFactory jsonSchemaSerdeFactory;
         @Mock private SchemaValidator validator;
         @Mock private GenericMapper<Object> mapper;

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/mapper/GenericMapperFactoryTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/mapper/GenericMapperFactoryTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.serde.json.mapper;
+
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GenericMapperFactoryTest {
+
+    @Mock private JsonMapper jsonMapper;
+
+    @Test
+    void shouldRegisterNamedSubtypes() {
+        // When:
+        new GenericMapperFactory(Map.of(String.class, "bob"), jsonMapper);
+
+        // Then:
+        verify(jsonMapper).registerSubtypes(new NamedType(String.class, "bob"));
+    }
+
+    @Test
+    void shouldRegisterUnnamedSubtypes() {
+        // When:
+        new GenericMapperFactory(Map.of(String.class, ""), jsonMapper);
+
+        // Then:
+        verify(jsonMapper).registerSubtypes(new NamedType(String.class, null));
+    }
+}

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TypeWithImplicitPolymorphism.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TypeWithImplicitPolymorphism.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2023-2024 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.kafka.serde.json.model;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.util.Objects;
+import org.creekservice.api.base.annotation.schema.GeneratesSchema;
+
+@GeneratesSchema
+public final class TypeWithImplicitPolymorphism {
+
+    private final Inner inner;
+
+    public TypeWithImplicitPolymorphism(@JsonProperty("inner") final Inner inner) {
+        this.inner = requireNonNull(inner, "inner");
+    }
+
+    @JsonGetter("inner")
+    public Inner inner() {
+        return inner;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final TypeWithImplicitPolymorphism testValueV1 = (TypeWithImplicitPolymorphism) o;
+        return Objects.equals(inner, testValueV1.inner);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(inner);
+    }
+
+    @Override
+    public String toString() {
+        return "TestValueWithEnum{" + "inner=" + inner + '}';
+    }
+
+    // Poly type with no explicit subtype info.
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+    private interface Inner {}
+
+    // With explicit logical name:
+    @JsonTypeName("the-explicit-name")
+    public static final class ExplicitlyNamed implements Inner {
+
+        private final String text;
+
+        public ExplicitlyNamed(@JsonProperty("text") final String text) {
+            this.text = text;
+        }
+
+        @SuppressWarnings("unused")
+        public String getText() {
+            return text;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final ExplicitlyNamed that = (ExplicitlyNamed) o;
+            return Objects.equals(text, that.text);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(text);
+        }
+
+        @Override
+        public String toString() {
+            return "InnerTypeA{" + "text='" + text + '\'' + '}';
+        }
+    }
+
+    // Without explicit logical name:
+    public static final class ImplicitlyNamed implements Inner {
+        private final int age;
+
+        public ImplicitlyNamed(@JsonProperty("age") final int age) {
+            this.age = age;
+        }
+
+        @SuppressWarnings("unused")
+        public int getAge() {
+            return age;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final ImplicitlyNamed that = (ImplicitlyNamed) o;
+            return age == that.age;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(age);
+        }
+
+        @Override
+        public String toString() {
+            return "InnerTypeB{" + "age='" + age + '\'' + '}';
+        }
+    }
+}

--- a/json-serde/src/test/resources/schema/json/org.creekservice.internal.kafka.serde.json.model.type_with_implicit_polymorphism.yml
+++ b/json-serde/src/test/resources/schema/json/org.creekservice.internal.kafka.serde.json.model.type_with_implicit_polymorphism.yml
@@ -1,0 +1,41 @@
+---
+# timestamp=1705844296318
+$schema: http://json-schema.org/draft-07/schema#
+title: Type With Implicit Polymorphism
+type: object
+additionalProperties: false
+properties:
+  inner:
+    oneOf:
+      - $ref: '#/definitions/ImplicitlyNamed'
+      - $ref: '#/definitions/the-explicit-name'
+definitions:
+  ImplicitlyNamed:
+    type: object
+    additionalProperties: false
+    properties:
+      '@type':
+        type: string
+        enum:
+          - TypeWithImplicitPolymorphism$ImplicitlyNamed
+        default: TypeWithImplicitPolymorphism$ImplicitlyNamed
+      age:
+        type: integer
+    title: TypeWithImplicitPolymorphism$ImplicitlyNamed
+    required:
+      - '@type'
+      - age
+  the-explicit-name:
+    type: object
+    additionalProperties: false
+    properties:
+      '@type':
+        type: string
+        enum:
+          - the-explicit-name
+        default: the-explicit-name
+      text:
+        type: string
+    title: the-explicit-name
+    required:
+      - '@type'

--- a/serde-test/README.md
+++ b/serde-test/README.md
@@ -3,3 +3,5 @@
 # Creek Kafka Serde Test utilities
 
 Contains helper utilities for testing serde providers.
+
+See Javadocs of classes with this model for more information.


### PR DESCRIPTION
fixes: https://github.com/creek-service/creek-kafka/issues/461

Subtypes can not be registered via the `JsonSerdeExtensionOptions` type.
