### PR TITLE
fix: add missing Javadoc and fix spotless formatting violation

### DIFF
--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/endpoint/SystemEnvSchemaRegistryEndpointLoader.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/endpoint/SystemEnvSchemaRegistryEndpointLoader.java
@@ -55,6 +55,7 @@ import org.creekservice.api.kafka.serde.json.schema.store.endpoint.SchemaStoreEn
 public final class SystemEnvSchemaRegistryEndpointLoader implements SchemaStoreEndpoints.Loader {
 
     private static final String SR_PREFIX = "SCHEMA_REGISTRY_";
+
     /**
      * Environment var used to set the endpoints for a schema registry instance.
      *

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/schema/OwnedJsonSchemaDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/schema/OwnedJsonSchemaDescriptor.java
@@ -18,4 +18,5 @@ package org.creekservice.api.kafka.metadata.schema;
 
 import org.creekservice.api.platform.metadata.OwnedResource;
 
+/** Descriptor for an owned JSON schema resource. */
 public interface OwnedJsonSchemaDescriptor<T> extends JsonSchemaDescriptor<T>, OwnedResource {}

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/schema/UnownedJsonSchemaDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/schema/UnownedJsonSchemaDescriptor.java
@@ -18,4 +18,5 @@ package org.creekservice.api.kafka.metadata.schema;
 
 import org.creekservice.api.platform.metadata.UnownedResource;
 
+/** Descriptor for an unowned JSON schema resource. */
 public interface UnownedJsonSchemaDescriptor<T> extends JsonSchemaDescriptor<T>, UnownedResource {}

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicDescriptor.java
@@ -73,10 +73,16 @@ public interface KafkaTopicDescriptor<K, V> extends ResourceDescriptor {
     /** Descriptor for part of a topic's record. */
     interface PartDescriptor<T> extends ResourceCollection {
 
+        /** Identifies which part of a Kafka record this descriptor describes. */
         enum Part {
+            /** The key part of the Kafka record. */
             key,
+            /** The value part of the Kafka record. */
             value;
 
+            /**
+             * @return {@code true} if this part is the key part.
+             */
             public boolean isKey() {
                 return this == key;
             }


### PR DESCRIPTION
## Root Cause

The Build workflow was failing due to two issues introduced in recent commits:

1. **Javadoc failures** (`metadata:javadoc` task) — `-Werror` caused the build to fail on missing Javadoc comments:
   - `KafkaTopicDescriptor.java`: `enum Part`, its constants (`key`, `value`), and `isKey()` method were missing Javadoc
   - `OwnedJsonSchemaDescriptor.java`: interface was missing a Javadoc comment
   - `UnownedJsonSchemaDescriptor.java`: interface was missing a Javadoc comment

2. **Spotless check failure** (`json-serde:spotlessJavaCheck` task) — `SystemEnvSchemaRegistryEndpointLoader.java` was missing a blank line between the `SR_PREFIX` field and the following Javadoc comment block.

## Changes

- Added Javadoc to `enum Part`, `key`, `value` constants, and `isKey()` in `KafkaTopicDescriptor.java`
- Added Javadoc to `OwnedJsonSchemaDescriptor` and `UnownedJsonSchemaDescriptor` interfaces
- Added missing blank line in `SystemEnvSchemaRegistryEndpointLoader.java` to satisfy spotless formatting rules