### PR TITLE
fix: use assertThatEventually for topic creation assertion

### DIFF
--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClientFunctionalTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClientFunctionalTest.java
@@ -19,8 +19,8 @@ package org.creekservice.internal.kafka.extension.client;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
 import static org.creekservice.api.kafka.metadata.topic.KafkaTopicDescriptor.DEFAULT_CLUSTER_NAME;
-import static org.creekservice.test.TopicDescriptors.TopicConfigBuilder.withPartitions;
 import static org.creekservice.api.test.hamcrest.AssertEventually.assertThatEventually;
+import static org.creekservice.test.TopicDescriptors.TopicConfigBuilder.withPartitions;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClientFunctionalTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClientFunctionalTest.java
@@ -20,6 +20,7 @@ import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CON
 import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
 import static org.creekservice.api.kafka.metadata.topic.KafkaTopicDescriptor.DEFAULT_CLUSTER_NAME;
 import static org.creekservice.test.TopicDescriptors.TopicConfigBuilder.withPartitions;
+import static org.creekservice.api.test.hamcrest.AssertEventually.assertThatEventually;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 
@@ -112,7 +113,7 @@ class KafkaTopicClientFunctionalTest {
         client.ensureTopicsExist(List.of(topic));
 
         // Then:
-        assertThat(topic, exists());
+        assertThatEventually(() -> topic, exists());
     }
 
     @Test


### PR DESCRIPTION
## Summary

`KafkaTopicClientFunctionalTest#shouldCreateTopicsThatDoNotExist` was intermittently failing on Kafka 2.8.2 (ZooKeeper-based) CI runs.

## Root Cause

After `ensureTopicsExist()` returns, the test immediately calls `assertThat(topic, exists())`. Although the `CreateTopics` request is confirmed by the broker controller before `ensureTopicsExist()` returns, **metadata propagation to other brokers is asynchronous** in ZooKeeper-based Kafka (2.x). The `DescribeTopics` query in the `exists()` matcher can race against this propagation, causing a false `Topic does not exist` assertion failure.

Kafka 3.x (KRaft) propagates metadata much faster, so all 3.x matrix jobs pass cleanly.

## Fix

Replace `assertThat(topic, exists())` with `assertThatEventually(() -> topic, exists())`, which retries with exponential back-off up to a 30-second timeout until the topic appears.