### PR TITLE
fix: use CREEK_PACKAGES_TOKEN secret for GitHub Packages Dependabot auth

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,8 @@ registries:
     url: https://s01.oss.sonatype.org/content/repositories/snapshots/
   creek-github-packages:
     type: maven-repository
-    url: https://maven.pkg.github.com/creek-service/*
-    username: "Creek-Bot-Token"
+    url: https://maven.pkg.github.com/creek-service/
+    username: x-access-token
     password: "\u0067hp_LtyvXrQZen3WlKenUhv21Mg6NG38jn0AO2YH"
 updates:
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ registries:
     type: maven-repository
     url: https://maven.pkg.github.com/creek-service/
     username: x-access-token
-    password: "\u0067hp_LtyvXrQZen3WlKenUhv21Mg6NG38jn0AO2YH"
+    password: ${{secrets.CREEK_PACKAGES_TOKEN}}
 updates:
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Replace `${{secrets.GITHUB_TOKEN}}` with `${{secrets.CREEK_PACKAGES_TOKEN}}` in the Dependabot registry configuration.

GITHUB_TOKEN is an invalid Dependabot secret name (names cannot start with GITHUB_). The org-level `CREEK_PACKAGES_TOKEN` Dependabot secret has been created with read:packages scope for the creek-service org.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>