### PR TITLE
fix: upgrade commons-validator to 1.10.1 to remediate CVE-2025-48734

### DIFF
--- a/json-serde/build.gradle.kts
+++ b/json-serde/build.gradle.kts
@@ -40,14 +40,6 @@ dependencies {
 
     implementation("io.confluent:kafka-schema-registry-client:$confluentVersion")
     implementation("io.confluent:kafka-json-schema-provider:$confluentVersion")
-    constraints {
-        implementation("org.scala-lang:scala-library:3.8.3") {
-            because("lower versions have security vulnerabilities")
-        }
-        implementation("commons-beanutils:commons-beanutils:1.11.0") {
-            because("CVE-2025-48734 / GHSA-wxr5-93ph-8wr9: versions below 1.11.0 are vulnerable")
-        }
-    }
 
     jsonSchemaGenerator("org.creekservice:creek-json-schema-generator:$creekVersion")
 
@@ -56,6 +48,15 @@ dependencies {
     testImplementation(project(":test-service-json"))
     testImplementation("org.testcontainers:testcontainers-junit-jupiter:$testContainersVersion")
     testImplementation("org.creekservice:creek-observability-logging-fixtures:$creekVersion")
+
+    constraints {
+        implementation("org.scala-lang:scala-library:3.8.3") {
+            because("lower versions have security vulnerabilities")
+        }
+        implementation("commons-validator:commons-validator:1.10.1") {
+            because("Moves commons-beanutils:commons-beanutils past version suffering from CVE-2025-48734 / GHSA-wxr5-93ph-8wr9")
+        }
+    }
 }
 
 // Patch Kafka Testcontainers jar into main test containers module to avoid split packages:

--- a/json-serde/build.gradle.kts
+++ b/json-serde/build.gradle.kts
@@ -44,6 +44,9 @@ dependencies {
         implementation("org.scala-lang:scala-library:3.8.3") {
             because("lower versions have security vulnerabilities")
         }
+        implementation("commons-beanutils:commons-beanutils:1.11.0") {
+            because("CVE-2025-48734 / GHSA-wxr5-93ph-8wr9: versions below 1.11.0 are vulnerable")
+        }
     }
 
     jsonSchemaGenerator("org.creekservice:creek-json-schema-generator:$creekVersion")


### PR DESCRIPTION
## Summary

Upgrades `commons-validator` to `1.10.1` to remediate [CVE-2025-48734](https://github.com/advisories/GHSA-wxr5-93ph-8wr9).

This is preferred over directly constraining `commons-beanutils` as it upgrades the intermediate dependency to a known-good version.

## Root Cause

`commons-beanutils:1.9.4` is pulled in transitively via:

```
:json-serde
  └── net.jimblackler.jsonschemafriend:core:0.12.5
        └── commons-validator:commons-validator:1.9.0
              └── commons-beanutils:commons-beanutils:1.9.4  ← vulnerable
```

This appears on the **runtime classpath** of `:json-serde`, meaning released JARs are affected.

## Fix

Added a dependency constraint in `:json-serde` to force `commons-validator` to `1.10.1`, which brings in `commons-beanutils:1.11.0` (the fixed version).