### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-module-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-module-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-sonatype-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-sonatype-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/build.gradle.kts
+++ b/client-extension/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/module-info.java
+++ b/client-extension/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/ClientsExtensionOptions.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/ClientsExtensionOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/KafkaClientsExtension.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/KafkaClientsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/KafkaClientsExtensionOptions.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/KafkaClientsExtensionOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/KafkaClientsExtensionProvider.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/KafkaClientsExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/client/MockTopicClient.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/client/MockTopicClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/client/TopicClient.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/client/TopicClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/config/ClustersProperties.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/config/ClustersProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/config/KafkaPropertyOverrides.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/config/KafkaPropertyOverrides.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/config/SystemEnvPropertyOverrides.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/config/SystemEnvPropertyOverrides.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/logging/LoggingField.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/logging/LoggingField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/api/kafka/extension/resource/KafkaTopic.java
+++ b/client-extension/src/main/java/org/creekservice/api/kafka/extension/resource/KafkaTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/ClientsExtension.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/ClientsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/KafkaClientModuleProperties.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/KafkaClientModuleProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClient.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/config/ClustersPropertiesFactory.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/config/ClustersPropertiesFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/config/SystemEnvProperties.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/config/SystemEnvProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/KafkaResourceValidator.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/KafkaResourceValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistry.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/Topic.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/Topic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/TopicCollector.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/TopicCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/TopicRegistrar.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/TopicRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/TopicRegistry.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/TopicRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/TopicResourceFactory.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/TopicResourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/TopicResourceHandler.java
+++ b/client-extension/src/main/java/org/creekservice/internal/kafka/extension/resource/TopicResourceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/ModuleTest.java
+++ b/client-extension/src/test/java/org/creekservice/ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/api/kafka/extension/KafkaClientsExtensionOptionsTest.java
+++ b/client-extension/src/test/java/org/creekservice/api/kafka/extension/KafkaClientsExtensionOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/api/kafka/extension/KafkaClientsExtensionProviderTest.java
+++ b/client-extension/src/test/java/org/creekservice/api/kafka/extension/KafkaClientsExtensionProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/api/kafka/extension/config/ClustersPropertiesTest.java
+++ b/client-extension/src/test/java/org/creekservice/api/kafka/extension/config/ClustersPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/api/kafka/extension/config/SystemEnvPropertyOverridesTest.java
+++ b/client-extension/src/test/java/org/creekservice/api/kafka/extension/config/SystemEnvPropertyOverridesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/ClientExtensionFunctionalTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/ClientExtensionFunctionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/ClientsExtensionTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/ClientsExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/KafkaClientModulePropertiesTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/KafkaClientModulePropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClientFunctionalTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClientFunctionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClientTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/client/KafkaTopicClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/config/ClustersPropertiesFactoryTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/config/ClustersPropertiesFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/config/SystemEnvPropertiesTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/config/SystemEnvPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/KafkaResourceValidatorTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/KafkaResourceValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistryTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/ResourceRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/TopicCollectorTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/TopicCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/TopicResourceFactoryTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/TopicResourceFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/TopicResourceHandlerTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/TopicResourceHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/TopicTest.java
+++ b/client-extension/src/test/java/org/creekservice/internal/kafka/extension/resource/TopicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-extension/src/test/java/org/creekservice/test/TopicDescriptors.java
+++ b/client-extension/src/test/java/org/creekservice/test/TopicDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@
   <!-- See https://checkstyle.org/config_header.html   -->
   <module name="RegexpHeader">
     <property name="header"
-            value="/\*\n\* Copyright (\d\d\d\d-)?2025 Creek Contributors \(https://github.com/creek-service\)$\n \*$\n \* Licensed under the Apache License, Version 2.0"/>
+            value="/\*\n\* Copyright (\d\d\d\d-)?2026 Creek Contributors \(https://github.com/creek-service\)$\n \*$\n \* Licensed under the Apache License, Version 2.0"/>
   </module>
 
   <module name="TreeWalker">

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/config/spotbugs/suppressions.xml
+++ b/config/spotbugs/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2025-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/docs-examples/build.gradle.kts
+++ b/docs-examples/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs-examples/settings.gradle.kts
+++ b/docs-examples/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs-examples/src/main/java/com/acme/examples/clients/ServiceMain.java
+++ b/docs-examples/src/main/java/com/acme/examples/clients/ServiceMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs-examples/src/main/java/com/acme/examples/serde/CustomSerdeFormatProvider.java
+++ b/docs-examples/src/main/java/com/acme/examples/serde/CustomSerdeFormatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs-examples/src/main/java/com/acme/examples/service/MyServiceDescriptor.java
+++ b/docs-examples/src/main/java/com/acme/examples/service/MyServiceDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs-examples/src/main/java/com/acme/examples/service/TopicConfigBuilder.java
+++ b/docs-examples/src/main/java/com/acme/examples/service/TopicConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs-examples/src/main/java/com/acme/examples/service/TopicDescriptors.java
+++ b/docs-examples/src/main/java/com/acme/examples/service/TopicDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs-examples/src/main/java/com/acme/examples/streams/ServiceMain.java
+++ b/docs-examples/src/main/java/com/acme/examples/streams/ServiceMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs-examples/src/main/java/com/acme/examples/streams/TopologyBuilder.java
+++ b/docs-examples/src/main/java/com/acme/examples/streams/TopologyBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs-examples/src/main/java/module-info.java
+++ b/docs-examples/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs-examples/src/test/java/com/acme/examples/streams/TopologyBuilderTest.java
+++ b/docs-examples/src/test/java/com/acme/examples/streams/TopologyBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/build.gradle.kts
+++ b/json-serde/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/module-info.java
+++ b/json-serde/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/JsonSerdeExtensionOptions.java
+++ b/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/JsonSerdeExtensionOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/schema/ConsumerSchema.java
+++ b/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/schema/ConsumerSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/schema/ProducerSchema.java
+++ b/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/schema/ProducerSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/schema/YamlSchema.java
+++ b/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/schema/YamlSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/schema/store/client/JsonSchemaStoreClient.java
+++ b/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/schema/store/client/JsonSchemaStoreClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/schema/store/client/MockJsonSchemaStoreClient.java
+++ b/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/schema/store/client/MockJsonSchemaStoreClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/schema/store/endpoint/MockEndpointsLoader.java
+++ b/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/schema/store/endpoint/MockEndpointsLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/schema/store/endpoint/SchemaStoreEndpoints.java
+++ b/json-serde/src/main/java/org/creekservice/api/kafka/serde/json/schema/store/endpoint/SchemaStoreEndpoints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/JsonSchemaSerdeProvider.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/JsonSchemaSerdeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/logging/LoggingField.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/logging/LoggingField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/mapper/BaseJsonMapper.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/mapper/BaseJsonMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/mapper/GenericMapper.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/mapper/GenericMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/mapper/JsonReader.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/mapper/JsonReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/mapper/JsonWriter.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/mapper/JsonWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/LocalSchemaLoader.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/LocalSchemaLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/SchemaException.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/SchemaException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/YamlSchemas.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/YamlSchemas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/resource/JsonSchemaResourceHandler.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/resource/JsonSchemaResourceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/resource/SchemaResourceValidator.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/resource/SchemaResourceValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/serde/JsonSchemaDeserializer.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/serde/JsonSchemaDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/serde/JsonSchemaSerdeFactory.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/serde/JsonSchemaSerdeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/serde/JsonSchemaSerializer.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/serde/JsonSchemaSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/RegisteredSchema.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/RegisteredSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/SchemaStore.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/SchemaStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/SrSchemaStore.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/SrSchemaStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/SrSchemaStores.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/SrSchemaStores.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/client/DefaultJsonSchemaRegistryClient.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/client/DefaultJsonSchemaRegistryClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/compatability/CompatabilityChecker.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/compatability/CompatabilityChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/endpoint/SystemEnvSchemaRegistryEndpointLoader.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/store/endpoint/SystemEnvSchemaRegistryEndpointLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/validation/SchemaFriendValidator.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/validation/SchemaFriendValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/validation/SchemaValidator.java
+++ b/json-serde/src/main/java/org/creekservice/internal/kafka/serde/json/schema/validation/SchemaValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/ModuleTest.java
+++ b/json-serde/src/test/java/org/creekservice/ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/api/kafka/serde/json/JsonSerdeExtensionOptionsTest.java
+++ b/json-serde/src/test/java/org/creekservice/api/kafka/serde/json/JsonSerdeExtensionOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/api/kafka/serde/json/schema/ConsumerSchemaTest.java
+++ b/json-serde/src/test/java/org/creekservice/api/kafka/serde/json/schema/ConsumerSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/api/kafka/serde/json/schema/ProducerSchemaTest.java
+++ b/json-serde/src/test/java/org/creekservice/api/kafka/serde/json/schema/ProducerSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/api/kafka/serde/json/schema/store/endpoint/SchemaStoreEndpointsTest.java
+++ b/json-serde/src/test/java/org/creekservice/api/kafka/serde/json/schema/store/endpoint/SchemaStoreEndpointsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/JsonSchemaSerdeFunctionalTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/JsonSchemaSerdeFunctionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/JsonSchemaSerdeProviderTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/JsonSchemaSerdeProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/SchemaEvolutionTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/SchemaEvolutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/SchemaRegistryContainer.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/SchemaRegistryContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/mapper/BaseJsonMapperTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/mapper/BaseJsonMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/mapper/GenericMapperTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/mapper/GenericMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/DateTimeTypes.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/DateTimeTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/IncompatibleValue.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/IncompatibleValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TemporalTypes.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TemporalTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestKeyAddingMandatory.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestKeyAddingMandatory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestKeyReAddNewIdDifferentType.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestKeyReAddNewIdDifferentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestKeyReAddNewIdSameType.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestKeyReAddNewIdSameType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestKeyRemovingMandatory.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestKeyRemovingMandatory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestKeyV0.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestKeyV0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestKeyV1.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestKeyV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestKeyV2.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestKeyV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestValueV0.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestValueV0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestValueV1.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestValueV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestValueV2.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TestValueV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TypeWithEnum.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TypeWithEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TypeWithExplicitPolymorphism.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TypeWithExplicitPolymorphism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TypeWithImplicitPolymorphism.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/TypeWithImplicitPolymorphism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/WithAmbiguousFloat.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/WithAmbiguousFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/WithEnum.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/WithEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/WithPrimitiveTypes.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/model/WithPrimitiveTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/LocalSchemaLoaderTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/LocalSchemaLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/YamlSchemasTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/YamlSchemasTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/resource/JsonSchemaResourceHandlerTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/resource/JsonSchemaResourceHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/resource/SchemaResourceValidatorTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/resource/SchemaResourceValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/serde/JsonSchemaDeserializerTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/serde/JsonSchemaDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/serde/JsonSchemaSerdeFactoryTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/serde/JsonSchemaSerdeFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/serde/JsonSchemaSerializerTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/serde/JsonSchemaSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/store/SrSchemaStoreTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/store/SrSchemaStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/store/SrSchemaStoresTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/store/SrSchemaStoresTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/store/client/DefaultJsonSchemaRegistryClientTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/store/client/DefaultJsonSchemaRegistryClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/store/endpoint/SystemEnvSchemaRegistryEndpointLoaderTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/store/endpoint/SystemEnvSchemaRegistryEndpointLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/validation/SchemaFriendValidatorTest.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/schema/validation/SchemaFriendValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/util/TopicDescriptors.java
+++ b/json-serde/src/test/java/org/creekservice/internal/kafka/serde/json/util/TopicDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/build.gradle.kts
+++ b/metadata/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/SerializationFormat.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/SerializationFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/schema/JsonSchemaDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/schema/JsonSchemaDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/schema/OwnedJsonSchemaDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/schema/OwnedJsonSchemaDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/schema/SchemaDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/schema/SchemaDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/schema/UnownedJsonSchemaDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/schema/UnownedJsonSchemaDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/serde/JsonSchemaKafkaSerde.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/serde/JsonSchemaKafkaSerde.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/serde/NativeKafkaSerde.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/serde/NativeKafkaSerde.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/CreatableKafkaTopic.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/CreatableKafkaTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/CreatableKafkaTopicInternal.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/CreatableKafkaTopicInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicConfig.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicDescriptor.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicInput.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicInternal.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicOutput.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/OwnedKafkaTopicInput.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/OwnedKafkaTopicInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/OwnedKafkaTopicOutput.java
+++ b/metadata/src/main/java/org/creekservice/api/kafka/metadata/topic/OwnedKafkaTopicOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/test/java/org/creekservice/ModuleTest.java
+++ b/metadata/src/test/java/org/creekservice/ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/test/java/org/creekservice/api/kafka/metadata/SerializationFormatTest.java
+++ b/metadata/src/test/java/org/creekservice/api/kafka/metadata/SerializationFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/test/java/org/creekservice/api/kafka/metadata/schema/SchemaDescriptorTest.java
+++ b/metadata/src/test/java/org/creekservice/api/kafka/metadata/schema/SchemaDescriptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/test/java/org/creekservice/api/kafka/metadata/serde/NativeKafkaSerdeTest.java
+++ b/metadata/src/test/java/org/creekservice/api/kafka/metadata/serde/NativeKafkaSerdeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/test/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicConfigTest.java
+++ b/metadata/src/test/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata/src/test/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicDescriptorTest.java
+++ b/metadata/src/test/java/org/creekservice/api/kafka/metadata/topic/KafkaTopicDescriptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde-test/build.gradle.kts
+++ b/serde-test/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde-test/src/main/java/module-info.java
+++ b/serde-test/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde-test/src/main/java/org/creekservice/api/kafka/serde/test/KafkaSerdeProviderFunctionalFixture.java
+++ b/serde-test/src/main/java/org/creekservice/api/kafka/serde/test/KafkaSerdeProviderFunctionalFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde-test/src/main/java/org/creekservice/api/kafka/serde/test/KafkaSerdeProviderTester.java
+++ b/serde-test/src/main/java/org/creekservice/api/kafka/serde/test/KafkaSerdeProviderTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde-test/src/test/java/org/creekservice/ModuleTest.java
+++ b/serde-test/src/test/java/org/creekservice/ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde-test/src/test/java/org/creekservice/api/kafka/serde/test/KafkaSerdeProviderFunctionalFixtureTest.java
+++ b/serde-test/src/test/java/org/creekservice/api/kafka/serde/test/KafkaSerdeProviderFunctionalFixtureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2024-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde-test/src/test/java/org/creekservice/internal/kafka/serde/test/util/TopicDescriptors.java
+++ b/serde-test/src/test/java/org/creekservice/internal/kafka/serde/test/util/TopicDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde/build.gradle.kts
+++ b/serde/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde/src/main/java/module-info.java
+++ b/serde/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde/src/main/java/org/creekservice/api/kafka/serde/provider/KafkaSerdeProvider.java
+++ b/serde/src/main/java/org/creekservice/api/kafka/serde/provider/KafkaSerdeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde/src/main/java/org/creekservice/api/kafka/serde/provider/KafkaSerdeProviders.java
+++ b/serde/src/main/java/org/creekservice/api/kafka/serde/provider/KafkaSerdeProviders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde/src/main/java/org/creekservice/internal/kafka/serde/provider/NativeKafkaSerdeProvider.java
+++ b/serde/src/main/java/org/creekservice/internal/kafka/serde/provider/NativeKafkaSerdeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde/src/main/java/org/creekservice/internal/kafka/serde/provider/ProviderLoader.java
+++ b/serde/src/main/java/org/creekservice/internal/kafka/serde/provider/ProviderLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde/src/test/java/org/creekservice/ModuleTest.java
+++ b/serde/src/test/java/org/creekservice/ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde/src/test/java/org/creekservice/api/kafka/serde/provider/KafkaSerdeProvidersTest.java
+++ b/serde/src/test/java/org/creekservice/api/kafka/serde/provider/KafkaSerdeProvidersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde/src/test/java/org/creekservice/internal/kafka/serde/provider/NativeKafkaSerdeProviderTest.java
+++ b/serde/src/test/java/org/creekservice/internal/kafka/serde/provider/NativeKafkaSerdeProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/serde/src/test/java/org/creekservice/internal/kafka/serde/provider/ProviderLoaderTest.java
+++ b/serde/src/test/java/org/creekservice/internal/kafka/serde/provider/ProviderLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/build.gradle.kts
+++ b/streams-extension/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/module-info.java
+++ b/streams-extension/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtension.java
+++ b/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtensionOptions.java
+++ b/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtensionOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtensionProvider.java
+++ b/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtensionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/exception/StreamsExceptionHandlers.java
+++ b/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/exception/StreamsExceptionHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/observation/KafkaMetricsFilter.java
+++ b/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/observation/KafkaMetricsFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/observation/KafkaMetricsPublisherOptions.java
+++ b/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/observation/KafkaMetricsPublisherOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/observation/LifecycleObserver.java
+++ b/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/observation/LifecycleObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/observation/StateRestoreObserver.java
+++ b/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/observation/StateRestoreObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/util/Name.java
+++ b/streams-extension/src/main/java/org/creekservice/api/kafka/streams/extension/util/Name.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/DefaultStreamsShutdownHook.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/DefaultStreamsShutdownHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsBuilder.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsExecutor.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/RestoreListener.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/RestoreListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsExtension.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsShutdownHook.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsShutdownHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsStateListener.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsStateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsVersions.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/StreamsVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultLifecycleObserver.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultLifecycleObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultMetricsFilter.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultMetricsFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultMetricsPublisher.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultMetricsPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultStateRestoreObserver.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultStateRestoreObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/observation/MetricsPublisher.java
+++ b/streams-extension/src/main/java/org/creekservice/internal/kafka/streams/extension/observation/MetricsPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/ModuleTest.java
+++ b/streams-extension/src/test/java/org/creekservice/ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtensionOptionsTest.java
+++ b/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtensionOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtensionProviderTest.java
+++ b/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/KafkaStreamsExtensionProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/exception/StreamsExceptionHandlersTest.java
+++ b/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/exception/StreamsExceptionHandlersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/observation/KafkaMetricsFilterTest.java
+++ b/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/observation/KafkaMetricsFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/observation/KafkaMetricsPublisherOptionsTest.java
+++ b/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/observation/KafkaMetricsPublisherOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/util/NameTest.java
+++ b/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/util/NameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/util/NamedAccessor.java
+++ b/streams-extension/src/test/java/org/creekservice/api/kafka/streams/extension/util/NamedAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/DefaultStreamsShutdownHookTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/DefaultStreamsShutdownHookTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsBuilderTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsExecutorTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/KafkaStreamsExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/RestoreListenerTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/RestoreListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsExtensionTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsStateListenerTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsStateListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsVersionsTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/StreamsVersionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultLifecycleObserverTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultLifecycleObserverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultMetricsFilterTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultMetricsFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultMetricsPublisherTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultMetricsPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultStateRestoreObserverTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/observation/DefaultStateRestoreObserverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/observation/LifecycleObserverTest.java
+++ b/streams-extension/src/test/java/org/creekservice/internal/kafka/streams/extension/observation/LifecycleObserverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-test/build.gradle.kts
+++ b/streams-test/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-test/src/main/java/org/creekservice/api/kafka/streams/test/TestKafkaStreamsExtensionOptions.java
+++ b/streams-test/src/main/java/org/creekservice/api/kafka/streams/test/TestKafkaStreamsExtensionOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-test/src/main/java/org/creekservice/api/kafka/streams/test/TestTopics.java
+++ b/streams-test/src/main/java/org/creekservice/api/kafka/streams/test/TestTopics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-test/src/test/java/org/creekservice/ModuleTest.java
+++ b/streams-test/src/test/java/org/creekservice/ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-test/src/test/java/org/creekservice/api/kafka/streams/test/TestKafkaClientsExtensionOptionsTest.java
+++ b/streams-test/src/test/java/org/creekservice/api/kafka/streams/test/TestKafkaClientsExtensionOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-test/src/test/java/org/creekservice/api/kafka/streams/test/TestTopicsTest.java
+++ b/streams-test/src/test/java/org/creekservice/api/kafka/streams/test/TestTopicsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-test/src/test/java/org/creekservice/internal/kafka/streams/test/util/NativeServiceDescriptor.java
+++ b/streams-test/src/test/java/org/creekservice/internal/kafka/streams/test/util/NativeServiceDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/streams-test/src/test/java/org/creekservice/internal/kafka/streams/test/util/TopicDescriptors.java
+++ b/streams-test/src/test/java/org/creekservice/internal/kafka/streams/test/util/TopicDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/build.gradle.kts
+++ b/test-extension/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/module-info.java
+++ b/test-extension/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/ClusterEndpointsProvider.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/ClusterEndpointsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtension.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/ConsumedRecord.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/ConsumedRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/MatchResult.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/MatchResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/MismatchDescription.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/MismatchDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/RecordCoercer.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/RecordCoercer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/RecordMatcher.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/RecordMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TestOptionsAccessor.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TestOptionsAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicConsumer.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicConsumers.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicConsumers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicExpectationException.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicExpectationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicExpectationHandler.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicExpectationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicInputHandler.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicInputHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicValidator.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicVerifier.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/KafkaOptions.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/KafkaOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicExpectation.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicExpectation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicInput.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicRecord.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDef.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/StartKafkaTestListener.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/StartKafkaTestListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/TopicValidatingListener.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/TopicValidatingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/util/ErrorMsgUtil.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/util/ErrorMsgUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/util/Optional3.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/util/Optional3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/yaml/JsonLocation.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/yaml/JsonLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/yaml/TypeCoercer.java
+++ b/test-extension/src/main/java/org/creekservice/internal/kafka/streams/test/extension/yaml/TypeCoercer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/ModuleTest.java
+++ b/test-extension/src/test/java/org/creekservice/ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/ClusterEndpointsProviderTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/ClusterEndpointsProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtensionFunctionalTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtensionFunctionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtensionTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/KafkaTestExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/MismatchDescriptionTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/MismatchDescriptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/RecordCoercerTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/RecordCoercerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/RecordMatcherTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/RecordMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TestOptionsAccessorKafka.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TestOptionsAccessorKafka.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicConsumerTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicConsumersTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicConsumersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicInputHandlerTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicInputHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicVerifierTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/handler/TopicVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/model/ModelUtil.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/model/ModelUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/model/TestOptionsKafka.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/model/TestOptionsKafka.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicExpectationTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicExpectationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicInputTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicRecordTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/model/TopicRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDefTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/KafkaContainerDefTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/StartKafkaTestListenerFunctionalTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/StartKafkaTestListenerFunctionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/StartKafkaTestListenerTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/StartKafkaTestListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/TopicValidatingListenerTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/testsuite/TopicValidatingListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/util/ErrorMsgUtilTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/util/ErrorMsgUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/util/Optional3Test.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/util/Optional3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/util/TopicDescriptors.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/util/TopicDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/yaml/JsonLocationTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/yaml/JsonLocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/yaml/TypeCoercerTest.java
+++ b/test-extension/src/test/java/org/creekservice/internal/kafka/streams/test/extension/yaml/TypeCoercerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-extension/src/test/resources/log4j2-test.xml
+++ b/test-extension/src/test/resources/log4j2-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/test-java-eight/build.gradle.kts
+++ b/test-java-eight/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-java-eight/src/main/java/org/creekservice/test/kafka/test/java/eight/KeepSpotBugsHappy.java
+++ b/test-java-eight/src/main/java/org/creekservice/test/kafka/test/java/eight/KeepSpotBugsHappy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-java-eight/src/test/java/org/creekservice/test/kafka/test/java/eight/SerdeExtensionTest.java
+++ b/test-java-eight/src/test/java/org/creekservice/test/kafka/test/java/eight/SerdeExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-java-eight/src/test/java/org/creekservice/test/kafka/test/java/eight/ServiceExtensionTest.java
+++ b/test-java-eight/src/test/java/org/creekservice/test/kafka/test/java/eight/ServiceExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-java-nine/build.gradle.kts
+++ b/test-java-nine/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-java-nine/src/main/java/org/creekservice/test/kafka/test/java/nine/KeepSpotBugsHappy.java
+++ b/test-java-nine/src/main/java/org/creekservice/test/kafka/test/java/nine/KeepSpotBugsHappy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-java-nine/src/test/java/org/creekservice/test/kafka/test/java/nine/SerdeExtensionTest.java
+++ b/test-java-nine/src/test/java/org/creekservice/test/kafka/test/java/nine/SerdeExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-java-nine/src/test/java/org/creekservice/test/kafka/test/java/nine/ServiceExtensionTest.java
+++ b/test-java-nine/src/test/java/org/creekservice/test/kafka/test/java/nine/ServiceExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-serde-java-eight/build.gradle.kts
+++ b/test-serde-java-eight/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-serde-java-eight/src/main/java/org/creekservice/test/api/kafka/serde/eight/test/BadJava8TestSerdeProvider.java
+++ b/test-serde-java-eight/src/main/java/org/creekservice/test/api/kafka/serde/eight/test/BadJava8TestSerdeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-serde-java-eight/src/main/java/org/creekservice/test/api/kafka/serde/eight/test/ExampleTestSerdeProvider.java
+++ b/test-serde-java-eight/src/main/java/org/creekservice/test/api/kafka/serde/eight/test/ExampleTestSerdeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-serde-java-eight/src/test/java/org/creekservice/test/api/kafka/serde/eight/test/KafkaSerdeProviderTesterTest.java
+++ b/test-serde-java-eight/src/test/java/org/creekservice/test/api/kafka/serde/eight/test/KafkaSerdeProviderTesterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-serde/build.gradle.kts
+++ b/test-serde/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-serde/src/main/java/module-info.java
+++ b/test-serde/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-serde/src/main/java/org/creekservice/test/api/kafka/serde/test/NeitherTestSerdeProvider.java
+++ b/test-serde/src/main/java/org/creekservice/test/api/kafka/serde/test/NeitherTestSerdeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-serde/src/main/java/org/creekservice/test/api/kafka/serde/test/OnlyMetaInfTestSerdeProvider.java
+++ b/test-serde/src/main/java/org/creekservice/test/api/kafka/serde/test/OnlyMetaInfTestSerdeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-serde/src/main/java/org/creekservice/test/api/kafka/serde/test/OnlyModuleTestSerdeProvider.java
+++ b/test-serde/src/main/java/org/creekservice/test/api/kafka/serde/test/OnlyModuleTestSerdeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-serde/src/main/java/org/creekservice/test/api/kafka/serde/test/PublicTestSerdeProvider.java
+++ b/test-serde/src/main/java/org/creekservice/test/api/kafka/serde/test/PublicTestSerdeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-serde/src/main/java/org/creekservice/test/internal/kafka/serde/test/PrivateTestSerdeProvider.java
+++ b/test-serde/src/main/java/org/creekservice/test/internal/kafka/serde/test/PrivateTestSerdeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-serde/src/test/java/org/creekservice/test/api/kafka/serde/test/KafkaSerdeProviderTesterTest.java
+++ b/test-serde/src/test/java/org/creekservice/test/api/kafka/serde/test/KafkaSerdeProviderTesterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-service-json/build.gradle.kts
+++ b/test-service-json/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-service-json/src/main/java/module-info.java
+++ b/test-service-json/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-service-json/src/main/java/org/creekservice/api/kafka/test/service/json/model/OutputValue.java
+++ b/test-service-json/src/main/java/org/creekservice/api/kafka/test/service/json/model/OutputValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-service-native/build.gradle.kts
+++ b/test-service-native/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-service-native/include/log4j/log4j2.xml
+++ b/test-service-native/include/log4j/log4j2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/test-service-native/src/main/java/module-info.java
+++ b/test-service-native/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-service-native/src/main/java/org/creekservice/api/kafka/test/service/inbuilt/NativeServiceDescriptor.java
+++ b/test-service-native/src/main/java/org/creekservice/api/kafka/test/service/inbuilt/NativeServiceDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-service-native/src/main/java/org/creekservice/api/kafka/test/service/inbuilt/UpstreamAggregateDescriptor.java
+++ b/test-service-native/src/main/java/org/creekservice/api/kafka/test/service/inbuilt/UpstreamAggregateDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-service-native/src/main/java/org/creekservice/internal/kafka/test/service/inbuilt/ServiceMain.java
+++ b/test-service-native/src/main/java/org/creekservice/internal/kafka/test/service/inbuilt/ServiceMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-service-native/src/main/java/org/creekservice/internal/kafka/test/service/inbuilt/TopicDescriptors.java
+++ b/test-service-native/src/main/java/org/creekservice/internal/kafka/test/service/inbuilt/TopicDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-service-native/src/main/java/org/creekservice/internal/kafka/test/service/inbuilt/kafka/streams/TopologyBuilder.java
+++ b/test-service-native/src/main/java/org/creekservice/internal/kafka/test/service/inbuilt/kafka/streams/TopologyBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update checkstyle header rule and existing copyright headers from 2025 to 2026.

Note: `./gradlew static` could not be fully verified locally as main source compilation requires SNAPSHOT dependencies not yet published (expected during active development). All copyright headers have been verified correct via manual grep.